### PR TITLE
Positional Args

### DIFF
--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -18,6 +18,9 @@
 # * required option "got the option" initializers
 _argproc_initStatements=()
 
+# List of functions to run to parse positional arguments.
+_argproc_positionalFuncs=()
+
 # List of statements to run after parsing, to do pre-return validation. This
 # includes:
 #
@@ -336,7 +339,7 @@ function opt-toggle {
 }
 
 # Declares a "value" option, specified as just `<name>` (no `<abbrev>` allowed
-# for these). When parsed value options require a value, passed in the form
+# for these). When parsed, value options require a value, passed in the form
 # `--<name>=<value>`. At least one of `--call` or `--var` must be used to define
 # the option.
 #
@@ -417,8 +420,8 @@ function opt-value {
     fi
 
     if (( ${required} )); then
-        # Replace `required` with a variable name based on the first
-        # option, and use it to form all the dependant bits.
+        # Replace `required` with a variable name based on the option name, and
+        # use it to form all the dependant bits.
         required="_argproc_gotOption_${name/-/_}"
         requiredSetter="${required}=1"
         _argproc_initStatements+=("local ${required}=0")
@@ -440,6 +443,107 @@ function opt-value {
         '"${setVar}"'
         '"${requiredSetter}"'
     }'
+}
+
+# Declares a positional argument, specified as just <name>, the name of the
+# argument to use in error messages and internal bookkeeping. At least one of
+# `--call` or `--var` must be used to define the argument.
+#
+# --call=<name> -- Calls the function with the given name, passing it the
+#   argument value. If `--var` is also used, the call is made first, and then
+#   the variable is set only if the call returned successfully.
+# --default=<value> -- The default value for the variable. If not specified, the
+#   default value is `''` (the empty string).
+# --match=<regex> -- Regular expression matched against the entire argument
+#   value. If the value does not match, then the argument gets rejected.
+# --required -- Indicates that this argument must be passed.
+# --var=<name> -- Sets the global `<name>` to the argument value. This also
+#   causes the variable to be initialized at the start of argument processing.
+function positional-args {
+    local callFunc=''
+    local defaultValue=''
+    local match=''
+    local setVar=''
+    local required=0
+    local ifMissing=''
+
+    while (( $# > 0 )); do
+        case "$1" in
+            --call=?*)
+                callFunc="${1#*=}"
+                ;;
+            --default=*)
+                defaultValue="${1#*=}"
+                ;;
+            --match=?*)
+                match="${1#*=}"
+                ;;
+            --required)
+                required=1
+                ;;
+            --var=?*)
+                setVar="${1#*=}"
+                ;;
+            *)
+                # End of options / unrecognized option.
+                break
+                ;;
+        esac
+        shift
+    done
+
+    local name="$1"
+
+    if ! [[ ${name} =~ ^[a-zA-Z0-9][-a-zA-Z0-9]*$ ]]; then
+        echo 1>&2 "Invalid argument spec: ${name}"
+        return 1
+    fi
+
+    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+        echo 1>&2 "Must use at least one of --call or --var for argument: ${name}."
+        return 1
+    fi
+
+    if [[ ${callFunc} != '' ]]; then
+        # Re-form as the caller code.
+        callFunc="${callFunc}"' "${value}" || return "$?"'
+    fi
+
+    if [[ ${setVar} != '' ]]; then
+        # Set up the default initializer, and then re-form as the setter code.
+        _argproc_initStatements+=("${setVar}=$(_argproc:quote "${defaultValue}")")
+        setVar="${setVar}"'="$1"'
+    fi
+
+    if [[ ${match} != '' ]]; then
+        # Re-form as the clause to insert to perform the check.
+        match='
+            elif ! [[ $1 =~ ^('"${match}"')$ ]]; then
+                echo 1>&2 "Invalid value for argument <'"${name}"'>."
+                echo 1>&2 "Value: $1"
+                return 1'
+    fi
+
+    if (( ${required} )); then
+        # Code to issue a complaint about the missing argument.
+        ifMissing='
+            echo 1>&2 "Missing required argument: <'"${name}"'>"
+            return 1'
+    else
+        ifMissing='return'
+    fi
+
+    eval 'function _argproc:positional-'"${name}"' {
+        if (( $# < 1 )); then
+            '"${ifMissing}"'
+        '"${match}"'
+        fi
+
+        '"${callFunc}"'
+        '"${setVar}"'
+    }'
+
+    _argproc_positionalFuncs+=("_argproc:positional-${name}")
 }
 
 # Prints a usage message. This is just a convenient shorthand to do just a few
@@ -612,7 +716,7 @@ function rest-arg {
 # read.
 function _argproc:statements-from-args {
     local argError=0
-    local arg handler name value
+    local arg handler name statement value
 
     while (( $# > 0 )); do
         arg="$1"
@@ -664,8 +768,16 @@ function _argproc:statements-from-args {
         shift
     done
 
+    for statement in "${_argproc_positionalFuncs[@]}"; do
+        if (( $# > 0 )); then
+            statement="${statement} $(_argproc:quote "$1")"
+            shift
+        fi
+        _argproc_statements+=("${statement}")
+    done
+
     if declare -F _argproc:rest >/dev/null; then
-        local statement="_argproc:rest $(_argproc:quote "$@")"
+        statement="_argproc:rest $(_argproc:quote "$@")"
         _argproc_statements+=("${statement}")
     elif (( $# > 0 )); then
         echo 1>&2 'Non-option arguments are not allowed.'

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -725,7 +725,7 @@ function _argproc:statements-from-args {
             # Explicit end of options.
             shift
             break
-        elif [[ ${arg} == '-' || ${arg} =~ ^[^-] ]]; then
+        elif [[ ${arg} == '' || ${arg} == '-' || ${arg} =~ ^[^-] ]]; then
             # Non-option argument.
             break
         elif [[ ${arg} =~ ^--([-a-zA-Z0-9]+)(=.*)?$ ]]; then

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -459,7 +459,7 @@ function opt-value {
 # --required -- Indicates that this argument must be passed.
 # --var=<name> -- Sets the global `<name>` to the argument value. This also
 #   causes the variable to be initialized at the start of argument processing.
-function positional-args {
+function positional-arg {
     local callFunc=''
     local defaultValue=''
     local match=''

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -780,7 +780,11 @@ function _argproc:statements-from-args {
         statement="_argproc:rest $(_argproc:quote "$@")"
         _argproc_statements+=("${statement}")
     elif (( $# > 0 )); then
-        echo 1>&2 'Non-option arguments are not allowed.'
+        if (( ${#_argproc_positionalFuncs[@]} == 0 )); then
+            echo 1>&2 'Non-option arguments are not allowed.'
+        else
+            echo 1>&2 'Too many arguments for command.'
+        fi
         argError=1
     fi
 

--- a/bin/lib/cidr-calc
+++ b/bin/lib/cidr-calc
@@ -75,20 +75,12 @@ opt-choice --var=outputStyle --default=string json string
 # Want help?
 opt-action --call=usage --value=0 help/h
 
-# Command and arguments.
-command=
-args=()
-rest-arg --call=parse-command
-function parse-command {
-    if (( $# == 0 )); then
-        echo 1>&2 'Missing command argument.'
-        return 1
-    fi
+# Command.
+positional-arg --var=command --required command
 
-    command="$1"
-    shift
-    args=("$@")
-}
+# Command arguments.
+args=()
+rest-arg --var=args
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/cidr-calc
+++ b/bin/lib/cidr-calc
@@ -76,7 +76,7 @@ opt-choice --var=outputStyle --default=string json string
 opt-action --call=usage --value=0 help/h
 
 # Command.
-positional-arg --var=command --required command
+positional-arg --required --var=command command
 
 # Command arguments.
 args=()

--- a/bin/lib/ip-permission-spec
+++ b/bin/lib/ip-permission-spec
@@ -49,7 +49,7 @@ opt-choice --var=outputStyle --default=json compact json
 positional-arg --required --var=protocol --match='all|tcp|udp' protocol
 
 # Port.
-positional-arg --required --var=port --match='[0-9]+' port
+positional-arg --required --var=port --match='[0-9]+|all' port
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/ip-permission-spec
+++ b/bin/lib/ip-permission-spec
@@ -46,39 +46,10 @@ opt-action --call=usage --value=0 help/h
 opt-choice --var=outputStyle --default=json compact json
 
 # Protocol.
-protocol=''
+positional-arg --required --var=protocol --match='all|tcp|udp' protocol
 
 # Port.
-port=''
-
-rest-arg --call=parse-spec
-function parse-spec {
-    if (( $# < 2 )); then
-        echo 1>&2 'Missing argument: protocol and/or port'
-        return 1
-    elif (( $# > 2 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    protocol="$1"
-    port="$2"
-
-    case "${protocol}" in
-        all|tcp|udp)
-            : # It's valid.
-            ;;
-        *)
-            echo 1>&2 "Invalid value for protocol: ${protocol}"
-            return 1
-            ;;
-    esac
-
-    if [[ ${port} != 'all' && ! ${port} =~ ^[0-9]+$ ]]; then
-        echo 1>&2 "Invalid value for port: ${port}"
-        return 1
-    fi
-}
+positional-arg --required --var=port --match='[0-9]+' port
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/json-get
+++ b/bin/lib/json-get
@@ -55,25 +55,11 @@ opt-action --call=usage --value=0 help/h
 # Output style.
 opt-choice --var=outputStyle --default=json compact json lines raw words
 
-# Value and expressions to operate on it.
-rest-arg --call=parse-value-and-exprs
-value=''
-exprArgs=('.')
-function parse-value-and-exprs {
-    if (( $# < 1 )); then
-        echo 1>&2 'Missing <json-value> argument.'
-        argError=1
-    fi
+# Value to operate on.
+positional-arg --required --var=value value
 
-    # JSON value.
-    value="$1"
-    shift
-
-    # Processing expressions.
-    if (( $# !=  0 )); then
-        exprArgs=("$@")
-    fi
-}
+# Expressions to operate on the value.
+rest-arg --var=exprArgs
 
 process-args "$@" || usage "$?"
 
@@ -81,5 +67,9 @@ process-args "$@" || usage "$?"
 #
 # Main script
 #
+
+if (( ${#exprArgs[@]} == 0 )); then
+    exprArgs=('.')
+fi
 
 lib json-val <<< "${value}" --"${outputStyle}" --read-stdin -- "${exprArgs[@]}"

--- a/bin/lib/json-length
+++ b/bin/lib/json-length
@@ -35,19 +35,7 @@ function usage {
 opt-action --call=usage --value=0 help/h
 
 # JSON value.
-rest-arg --call=parse-rest
-value=''
-function parse-rest {
-    if (( $# < 1 )); then
-        echo 1>&2 'Missing argument: <json-value>'
-        return 1
-    elif (( $# > 1 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    value="$1"
-}
+positional-arg --required --var=value json-value
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/name-tag-spec
+++ b/bin/lib/name-tag-spec
@@ -47,24 +47,10 @@ opt-action --call=usage --value=0 help/h
 opt-choice --var=outputStyle --default=json compact json
 
 # Resource type.
-resourceType=''
+positional-arg --required --var=resourceType --match='[-a-z0-9]+' resource-type
 
 # Name for the resource.
-name=''
-
-rest-arg --call=parse-rest
-function parse-rest {
-    if (( $# < 2 )); then
-        echo 1>&2 'Missing argument: resource type and/or name'
-        return 1
-    elif (( $# > 2 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    resourceType="$1"
-    name="$2"
-}
+positional-arg --required --var=name --match='.+' name
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/now-stamp
+++ b/bin/lib/now-stamp
@@ -37,18 +37,7 @@ function usage {
 opt-action --call=usage --value=0 help/h
 
 # Suffix text.
-suffix=''
-rest-arg --call=parse-rest
-function parse-rest {
-    if (( $# < 1 )); then
-        return
-    elif (( $# > 1 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    suffix="$1"
-}
+positional-arg --var=suffix --match='[-_:./a-zA-Z0-9]+' suffix
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/parse-location
+++ b/bin/lib/parse-location
@@ -63,19 +63,7 @@ opt-choice --var=printItem --default=print-none \
     print-none print-region print-zone print-zone-suffix
 
 # Location (availability zone or region).
-inLocation=''
-rest-arg --call=parse-rest
-function parse-rest {
-    if (( $# < 1 )); then
-        echo 1>&2 'Missing argument: <zone-or-region>'
-        return 1
-    elif (( $# > 1 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    inLocation="$1"
-}
+positional-arg --required --var=inLocation zone-or-region
 
 process-args "$@" || usage "$?"
 
@@ -90,7 +78,7 @@ fi
 #
 
 # Split into region and zone suffix, or die trying.
-if [[ ! ${inLocation} =~ ^([a-z]{2}-[a-z]+-[0-9]+)([a-z]|-[a-z]+-[0-9][a-z])?$ ]]; then
+if [[ ! ${inLocation} =~ ^([a-z]{2}-[a-z]+-[0-9]+)([a-z]|-[a-z]+-[0-9]+[a-z])?$ ]]; then
     echo 1>&2 'Unparseable location:' "${inLocation}"
     exit 1
 fi

--- a/bin/lib/region-from-location
+++ b/bin/lib/region-from-location
@@ -34,19 +34,7 @@ function usage {
 opt-action --call=usage --value=0 help/h
 
 # Location (availability zone or region).
-inLocation=''
-rest-arg --call=parse-rest
-function parse-rest {
-    if (( $# < 1 )); then
-        echo 1>&2 'Missing argument: <zone-or-region>'
-        return 1
-    elif (( $# > 1 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    inLocation="$1"
-}
+positional-arg --required --var=inLocation zone-or-region
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/region-from-zone
+++ b/bin/lib/region-from-zone
@@ -34,19 +34,7 @@ function usage {
 opt-action --call=usage --value=0 help/h
 
 # Availability zone.
-inZone=''
-rest-arg --call=parse-rest
-function parse-rest {
-    if (( $# < 1 )); then
-        echo 1>&2 'Missing argument: <zone>'
-        return 1
-    elif (( $# > 1 )); then
-        echo 1>&2 'Too many arguments.'
-        return 1
-    fi
-
-    inZone="$1"
-}
+positional-arg --required --var=inZone zone
 
 process-args "$@" || usage "$?"
 


### PR DESCRIPTION
This adds `positional-arg` to `arg-processor`, and uses it in every script that (a) has positional args and (b) already uses `arg-processor`.