### PR TITLE
DRY the arg processor.

### DIFF
--- a/bin/find-ami
+++ b/bin/find-ami
@@ -53,7 +53,7 @@ opt-action --call=usage --value=0 help/h
 opt-value --required --var=inLocation in
 
 # Instance type.
-opt-value --required --var=instanceType instance-type
+opt-value --required --var=instanceType --match='[a-z0-9]+\.[a-z0-9]+' instance-type
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -229,6 +229,10 @@ function opt-toggle {
     local optCall=''
     local optVar=''
 
+    ################################
+    ################################ CONVERT THIS ONE NEXT TO janky-args
+    ################################
+
     while (( $# > 0 )); do
         case "$1" in
             --call=?*)
@@ -681,7 +685,7 @@ function rest-arg {
 # caller) contains all the arguments, which gets updates by this function.
 function _argproc_janky-args {
     local argError=0
-    local argSpecs=" $* "
+    local argSpecs=" $* " # Spaces on the ends to make the match code work.
     local optsDone=0
     local a
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -55,36 +55,7 @@ function opt-action {
     _argproc_janky-args call default value var \
     || return 1
 
-    # TODO: Convert the rest of this to deal with the new args stuff.
-
-    local callFunc=''
-    local defaultValue=0
-    local setVar=''
-    local value='1'
-
-    while (( $# > 0 )); do
-        case "$1" in
-            --call=?*)
-                callFunc="${1#*=}"
-                ;;
-            --default=*)
-                defaultValue="${1#*=}"
-                ;;
-            --value=*)
-                value="${1#*=}"
-                ;;
-            --var=?*)
-                setVar="${1#*=}"
-                ;;
-            *)
-                # End of options / unrecognized option.
-                break
-                ;;
-        esac
-        shift
-    done
-
-    local name="$1"
+    local name="${args[0]}"
 
     if ! [[ ${name} =~ ^([a-zA-Z0-9][-a-zA-Z0-9]*)(/[a-zA-Z0-9])?$ ]]; then
         echo 1>&2 "Invalid option spec: ${name}"
@@ -94,20 +65,20 @@ function opt-action {
     name="${BASH_REMATCH[1]}"
     local abbrev="${BASH_REMATCH[2]:1}" # `:1` to drop the slash.
 
-    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${optSet} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
 
-    if [[ ${callFunc} != '' ]]; then
+    if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc} $(_argproc:quote "${value}")"' || return "$?"'
+        optCall="${optCall} $(_argproc:quote "${optValue}")"' || return "$?"'
     fi
 
-    if [[ ${setVar} != '' ]]; then
+    if [[ ${optSet} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${setVar}=$(_argproc:quote "${defaultValue}")")
-        setVar="${setVar}=$(_argproc:quote "${value}")"
+        _argproc_initStatements+=("${optSet}=$(_argproc:quote "${optDefault}")")
+        optSet="${optSet}=$(_argproc:quote "${optValue}")"
     fi
 
     eval 'function _argproc:long-'"${name}"' {
@@ -116,8 +87,8 @@ function opt-action {
             return 1
         fi
 
-        '"${callFunc}"'
-        '"${setVar}"'
+        '"${optCall}"'
+        '"${optSet}"'
     }'
 
     if [[ ${abbrev} != '' ]]; then

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -117,36 +117,22 @@ function opt-action {
 function opt-choice {
     local optCall=''
     local optDefault=''
+    local optRequired=0
     local optVar=''
+    local args=("$@")
+    _argproc_janky-args call default required var \
+    || return 1
 
     local requiredName=''
     local requiredSetter=''
     local requiredError=''
 
-    while (( $# > 0 )); do
-        case "$1" in
-            --call=?*)
-                optCall="${1#*=}"
-                ;;
-            --default=*)
-                optDefault="${1#*=}"
-                ;;
-            --required)
-                requiredName='?' # Gets replaced with a valid long name.
-                ;;
-            --var=?*)
-                optVar="${1#*=}"
-                ;;
-            *)
-                # End of options / unrecognized option.
-                break
-                ;;
-        esac
-        shift
-    done
+    if (( optRequired )); then
+        # Gets replaced with a valid long name.
+        requiredName='?'
+    fi
 
-    local specs=("$@")
-    if (( ${#specs[@]} < 1 )); then
+    if (( ${#args[@]} < 1 )); then
         echo 1>&2 'Need at least one option spec for a choice.'
         return 1
     fi
@@ -168,7 +154,7 @@ function opt-choice {
     fi
 
     local s
-    for s in "${specs[@]}"; do
+    for s in "${args[@]}"; do
         if ! [[ ${s} =~ ^([a-zA-Z0-9][-a-zA-Z0-9]*)(/[a-zA-Z0-9])?(=(.*))?$ ]]; then
             echo 1>&2 "Invalid option spec: ${s}"
             return 1
@@ -705,7 +691,7 @@ function _argproc_janky-args {
             continue
         fi
 
-        if [[ ${a} =~ --(.+) ]]; then
+        if [[ ${a} =~ ^--. ]]; then
             if ! [[ ${a} =~ ^--([a-z]+)(=.*)?$ ]]; then
                 echo 1>&2 "Invalid option syntax: ${a}"
                 return 1
@@ -728,6 +714,11 @@ function _argproc_janky-args {
                 default)
                     [[ ${value} =~ ^=(.*)$ ]] \
                     && optDefault="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
+                required)
+                    [[ ${value} == '' ]] \
+                    && optRequired=1 \
                     || argError=1
                     ;;
                 value)

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -744,7 +744,7 @@ function _argproc_janky-args {
             local value="${BASH_REMATCH[2]}"
 
             if ! [[ ${argSpecs} =~ " ${name} " ]]; then
-                echo 1>&2 "Unknown option: ${name}"
+                echo 1>&2 "Unknown option: --${name}"
                 return 1
             fi
 
@@ -772,7 +772,11 @@ function _argproc_janky-args {
             esac
 
             if (( argError )); then
-                echo 1>&2 "Invalid value for option --${name}."
+                if [[ ${value} != '' ]]; then
+                    echo 1>&2 "Invalid value for option --${name}: ${value:1}"
+                else
+                    echo 1>&2 "Value required for option --${name}."
+                fi
                 return 1
             fi
         elif [[ ${a} == '--' ]]; then

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -115,7 +115,7 @@ function opt-action {
 # --var=<name> -- Sets the global `<name>` to the option value, and causes it to
 #   be defaulted at the start of argument processing.
 function opt-choice {
-    local callFunc=''
+    local optCall=''
     local defaultValue=''
     local setVar=''
 
@@ -126,7 +126,7 @@ function opt-choice {
     while (( $# > 0 )); do
         case "$1" in
             --call=?*)
-                callFunc="${1#*=}"
+                optCall="${1#*=}"
                 ;;
             --default=*)
                 defaultValue="${1#*=}"
@@ -151,14 +151,14 @@ function opt-choice {
         return 1
     fi
 
-    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
 
-    if [[ ${callFunc} != '' ]]; then
+    if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc}"' "${_approc_value}" || return "$?"'
+        optCall="${optCall}"' "${_approc_value}" || return "$?"'
     fi
 
     if [[ ${setVar} != '' ]]; then
@@ -205,7 +205,7 @@ function opt-choice {
             fi
 
             local _argproc_value='"${value}"'
-            '"${callFunc}"'
+            '"${optCall}"'
             '"${setVar}"'
             '"${requiredSetter}"'
         }'
@@ -240,13 +240,13 @@ function opt-choice {
 # --var=<name> -- Sets the global `<name>` to `1` or `0`, and causes it to be
 #   defauled to `0` at the start of argument processing.
 function opt-toggle {
-    local callFunc=''
+    local optCall=''
     local setVar=''
 
     while (( $# > 0 )); do
         case "$1" in
             --call=?*)
-                callFunc="${1#*=}"
+                optCall="${1#*=}"
                 ;;
             --var=?*)
                 setVar="${1#*=}"
@@ -270,14 +270,14 @@ function opt-toggle {
     local abbrevOn="${BASH_REMATCH[2]:1}"  # `:1` to drop the slash.
     local abbrevOff="${BASH_REMATCH[3]:1}" # Likewise.
 
-    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
 
-    if [[ ${callFunc} != '' ]]; then
+    if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc}"' "$1" || return "$?"'
+        optCall="${optCall}"' "$1" || return "$?"'
     fi
 
     if [[ ${setVar} != '' ]]; then
@@ -293,7 +293,7 @@ function opt-toggle {
                 return 1
             fi
 
-            '"${callFunc}"'
+            '"${optCall}"'
             '"${setVar}"'
         }
 
@@ -336,7 +336,7 @@ function opt-toggle {
 #   argument. This also causes the variable to be initialized at the start of
 #   argument processing.
 function opt-value {
-    local callFunc=''
+    local optCall=''
     local defaultValue=''
     local match=''
     local setVar=''
@@ -346,7 +346,7 @@ function opt-value {
     while (( $# > 0 )); do
         case "$1" in
             --call=?*)
-                callFunc="${1#*=}"
+                optCall="${1#*=}"
                 ;;
             --default=*)
                 defaultValue="${1#*=}"
@@ -375,14 +375,14 @@ function opt-value {
         return 1
     fi
 
-    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
 
-    if [[ ${callFunc} != '' ]]; then
+    if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc}"' "${value}" || return "$?"'
+        optCall="${optCall}"' "${value}" || return "$?"'
     fi
 
     if [[ ${setVar} != '' ]]; then
@@ -420,7 +420,7 @@ function opt-value {
         '"${match}"'
         fi
 
-        '"${callFunc}"'
+        '"${optCall}"'
         '"${setVar}"'
         '"${requiredSetter}"'
     }'
@@ -441,7 +441,7 @@ function opt-value {
 # --var=<name> -- Sets the global `<name>` to the argument value. This also
 #   causes the variable to be initialized at the start of argument processing.
 function positional-arg {
-    local callFunc=''
+    local optCall=''
     local defaultValue=''
     local match=''
     local setVar=''
@@ -451,7 +451,7 @@ function positional-arg {
     while (( $# > 0 )); do
         case "$1" in
             --call=?*)
-                callFunc="${1#*=}"
+                optCall="${1#*=}"
                 ;;
             --default=*)
                 defaultValue="${1#*=}"
@@ -480,14 +480,14 @@ function positional-arg {
         return 1
     fi
 
-    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for argument: ${name}."
         return 1
     fi
 
-    if [[ ${callFunc} != '' ]]; then
+    if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc}"' "${value}" || return "$?"'
+        optCall="${optCall}"' "${value}" || return "$?"'
     fi
 
     if [[ ${setVar} != '' ]]; then
@@ -520,7 +520,7 @@ function positional-arg {
         '"${match}"'
         fi
 
-        '"${callFunc}"'
+        '"${optCall}"'
         '"${setVar}"'
     }'
 
@@ -641,13 +641,13 @@ function process-args {
 #   arguments. This also causes the variable to be initialized to an empty
 #   array at the start of argument processing.
 function rest-arg {
-    local callFunc=''
+    local optCall=''
     local setVar=''
 
     while (( $# > 0 )); do
         case "$1" in
             --call=?*)
-                callFunc="${1#*=}"
+                optCall="${1#*=}"
                 ;;
             --var=?*)
                 setVar="${1#*=}"
@@ -660,14 +660,14 @@ function rest-arg {
         shift
     done
 
-    if [[ ${callFunc} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
         echo 1>&2 'Must use at least one of --call or --var for rest argument.'
         return 1
     fi
 
-    if [[ ${callFunc} != '' ]]; then
+    if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc}"' "$@" || return "$?"'
+        optCall="${optCall}"' "$@" || return "$?"'
     fi
 
     if [[ ${setVar} != '' ]]; then
@@ -677,7 +677,7 @@ function rest-arg {
     fi
 
     eval 'function _argproc:rest {
-        '"${callFunc}"'
+        '"${optCall}"'
         '"${setVar}"'
     }'
 }

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -65,7 +65,7 @@ function opt-action {
     name="${BASH_REMATCH[1]}"
     local abbrev="${BASH_REMATCH[2]:1}" # `:1` to drop the slash.
 
-    if [[ ${optCall} == '' && ${optSet} == '' ]]; then
+    if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
@@ -75,10 +75,10 @@ function opt-action {
         optCall="${optCall} $(_argproc:quote "${optValue}")"' || return "$?"'
     fi
 
-    if [[ ${optSet} != '' ]]; then
+    if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${optSet}=$(_argproc:quote "${optDefault}")")
-        optSet="${optSet}=$(_argproc:quote "${optValue}")"
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${optDefault}")")
+        optVar="${optVar}=$(_argproc:quote "${optValue}")"
     fi
 
     eval 'function _argproc:long-'"${name}"' {
@@ -88,7 +88,7 @@ function opt-action {
         fi
 
         '"${optCall}"'
-        '"${optSet}"'
+        '"${optVar}"'
     }'
 
     if [[ ${abbrev} != '' ]]; then
@@ -340,7 +340,7 @@ function opt-value {
     local optDefault=''
     local match=''
     local optVar=''
-    local required=0
+    local optRequired=0
     local requiredSetter=''
 
     while (( $# > 0 )); do
@@ -355,7 +355,7 @@ function opt-value {
                 match="${1#*=}"
                 ;;
             --required)
-                required=1
+                optRequired=1
                 ;;
             --var=?*)
                 optVar="${1#*=}"
@@ -400,14 +400,14 @@ function opt-value {
                 return 1'
     fi
 
-    if (( ${required} )); then
-        # Replace `required` with a variable name based on the option name, and
-        # use it to form all the dependant bits.
-        required="_argproc_gotOption_${name/-/_}"
-        requiredSetter="${required}=1"
-        _argproc_initStatements+=("local ${required}=0")
+    if (( ${optRequired} )); then
+        # Replace `optRequired` with a variable name based on the option name,
+        # and use it to form all the dependant bits.
+        optRequired="_argproc_gotOption_${name/-/_}"
+        requiredSetter="${optRequired}=1"
+        _argproc_initStatements+=("local ${optRequired}=0")
         _argproc_preReturnStatements+=('
-            (( '"${required}"' )) || {
+            (( '"${optRequired}"' )) || {
                 echo 1>&2 "Missing required option: --'"${name}"'"
                 false
             }')
@@ -445,7 +445,7 @@ function positional-arg {
     local optDefault=''
     local match=''
     local optVar=''
-    local required=0
+    local optRequired=0
     local ifMissing=''
 
     while (( $# > 0 )); do
@@ -460,7 +460,7 @@ function positional-arg {
                 match="${1#*=}"
                 ;;
             --required)
-                required=1
+                optRequired=1
                 ;;
             --var=?*)
                 optVar="${1#*=}"
@@ -505,7 +505,7 @@ function positional-arg {
                 return 1'
     fi
 
-    if (( ${required} )); then
+    if (( ${optRequired} )); then
         # Code to issue a complaint about the missing argument.
         ifMissing='
             echo 1>&2 "Missing required argument: <'"${name}"'>"

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -312,36 +312,13 @@ function opt-value {
     local optCall=''
     local optDefault=''
     local optMatch=''
-    local optVar=''
     local optRequired=0
-    local requiredSetter=''
+    local optVar=''
+    local args=("$@")
+    _argproc_janky-args call default match required var \
+    || return 1
 
-    while (( $# > 0 )); do
-        case "$1" in
-            --call=?*)
-                optCall="${1#*=}"
-                ;;
-            --default=*)
-                optDefault="${1#*=}"
-                ;;
-            --match=?*)
-                optMatch="${1#*=}"
-                ;;
-            --required)
-                optRequired=1
-                ;;
-            --var=?*)
-                optVar="${1#*=}"
-                ;;
-            *)
-                # End of options / unrecognized option.
-                break
-                ;;
-        esac
-        shift
-    done
-
-    local name="$1"
+    local name="${args[0]}"
 
     if ! [[ ${name} =~ ^[a-zA-Z0-9][-a-zA-Z0-9]*$ ]]; then
         echo 1>&2 "Invalid option spec: ${name}"
@@ -373,6 +350,7 @@ function opt-value {
                 return 1'
     fi
 
+    local requiredSetter=''
     if (( ${optRequired} )); then
         # Replace `optRequired` with a variable name based on the option name,
         # and use it to form all the dependant bits.
@@ -703,6 +681,11 @@ function _argproc_janky-args {
                     && optDefault="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
+                match)
+                    [[ ${value} =~ ^=(.*)$ ]] \
+                    && optMatch="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
                 required)
                     [[ ${value} == '' ]] \
                     && optRequired=1 \
@@ -717,6 +700,10 @@ function _argproc_janky-args {
                     [[ ${value} =~ ^=([_a-zA-Z][_a-zA-Z0-9]*)$ ]] \
                     && optVar="${BASH_REMATCH[1]}" \
                     || argError=1
+                    ;;
+                *)
+                    echo 1>&2 "Unknown arg-processing option: --${name}"
+                    return 1
                     ;;
             esac
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -750,7 +750,7 @@ function _argproc_janky-args {
 
             case "${name}" in
                 call)
-                    [[ ${value} =~ ^=([-_a-zA-Z0-9]+)$ ]] \
+                    [[ ${value} =~ ^=([-_a-zA-Z][-_a-zA-Z0-9]*)$ ]] \
                     && optCall="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
@@ -765,7 +765,7 @@ function _argproc_janky-args {
                     || argError=1
                     ;;
                 var)
-                    [[ ${value} =~ ^=([_a-zA-Z0-9]+)$ ]] \
+                    [[ ${value} =~ ^=([_a-zA-Z][_a-zA-Z0-9]*)$ ]] \
                     && optVar="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -117,7 +117,7 @@ function opt-action {
 function opt-choice {
     local optCall=''
     local defaultValue=''
-    local setVar=''
+    local optVar=''
 
     local requiredName=''
     local requiredSetter=''
@@ -135,7 +135,7 @@ function opt-choice {
                 requiredName='?' # Gets replaced with a valid long name.
                 ;;
             --var=?*)
-                setVar="${1#*=}"
+                optVar="${1#*=}"
                 ;;
             *)
                 # End of options / unrecognized option.
@@ -151,7 +151,7 @@ function opt-choice {
         return 1
     fi
 
-    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
@@ -161,10 +161,10 @@ function opt-choice {
         optCall="${optCall}"' "${_approc_value}" || return "$?"'
     fi
 
-    if [[ ${setVar} != '' ]]; then
+    if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${setVar}=$(_argproc:quote "${defaultValue}")")
-        setVar="${setVar}"'="${_argproc_value}"'
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${defaultValue}")")
+        optVar="${optVar}"'="${_argproc_value}"'
     fi
 
     local s
@@ -206,7 +206,7 @@ function opt-choice {
 
             local _argproc_value='"${value}"'
             '"${optCall}"'
-            '"${setVar}"'
+            '"${optVar}"'
             '"${requiredSetter}"'
         }'
 
@@ -241,7 +241,7 @@ function opt-choice {
 #   defauled to `0` at the start of argument processing.
 function opt-toggle {
     local optCall=''
-    local setVar=''
+    local optVar=''
 
     while (( $# > 0 )); do
         case "$1" in
@@ -249,7 +249,7 @@ function opt-toggle {
                 optCall="${1#*=}"
                 ;;
             --var=?*)
-                setVar="${1#*=}"
+                optVar="${1#*=}"
                 ;;
             *)
                 # End of options / unrecognized option.
@@ -270,7 +270,7 @@ function opt-toggle {
     local abbrevOn="${BASH_REMATCH[2]:1}"  # `:1` to drop the slash.
     local abbrevOff="${BASH_REMATCH[3]:1}" # Likewise.
 
-    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
@@ -280,10 +280,10 @@ function opt-toggle {
         optCall="${optCall}"' "$1" || return "$?"'
     fi
 
-    if [[ ${setVar} != '' ]]; then
+    if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${setVar}=0")
-        setVar="${setVar}"'="$1"'
+        _argproc_initStatements+=("${optVar}=0")
+        optVar="${optVar}"'="$1"'
     fi
 
     eval '
@@ -294,7 +294,7 @@ function opt-toggle {
             fi
 
             '"${optCall}"'
-            '"${setVar}"'
+            '"${optVar}"'
         }
 
         function _argproc:long-'"${name}"' {
@@ -339,7 +339,7 @@ function opt-value {
     local optCall=''
     local defaultValue=''
     local match=''
-    local setVar=''
+    local optVar=''
     local required=0
     local requiredSetter=''
 
@@ -358,7 +358,7 @@ function opt-value {
                 required=1
                 ;;
             --var=?*)
-                setVar="${1#*=}"
+                optVar="${1#*=}"
                 ;;
             *)
                 # End of options / unrecognized option.
@@ -375,7 +375,7 @@ function opt-value {
         return 1
     fi
 
-    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for option: ${name}."
         return 1
     fi
@@ -385,10 +385,10 @@ function opt-value {
         optCall="${optCall}"' "${value}" || return "$?"'
     fi
 
-    if [[ ${setVar} != '' ]]; then
+    if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${setVar}=$(_argproc:quote "${defaultValue}")")
-        setVar="${setVar}"'="$1"'
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${defaultValue}")")
+        optVar="${optVar}"'="$1"'
     fi
 
     if [[ ${match} != '' ]]; then
@@ -421,7 +421,7 @@ function opt-value {
         fi
 
         '"${optCall}"'
-        '"${setVar}"'
+        '"${optVar}"'
         '"${requiredSetter}"'
     }'
 }
@@ -444,7 +444,7 @@ function positional-arg {
     local optCall=''
     local defaultValue=''
     local match=''
-    local setVar=''
+    local optVar=''
     local required=0
     local ifMissing=''
 
@@ -463,7 +463,7 @@ function positional-arg {
                 required=1
                 ;;
             --var=?*)
-                setVar="${1#*=}"
+                optVar="${1#*=}"
                 ;;
             *)
                 # End of options / unrecognized option.
@@ -480,7 +480,7 @@ function positional-arg {
         return 1
     fi
 
-    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 "Must use at least one of --call or --var for argument: ${name}."
         return 1
     fi
@@ -490,10 +490,10 @@ function positional-arg {
         optCall="${optCall}"' "${value}" || return "$?"'
     fi
 
-    if [[ ${setVar} != '' ]]; then
+    if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${setVar}=$(_argproc:quote "${defaultValue}")")
-        setVar="${setVar}"'="$1"'
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${defaultValue}")")
+        optVar="${optVar}"'="$1"'
     fi
 
     if [[ ${match} != '' ]]; then
@@ -521,7 +521,7 @@ function positional-arg {
         fi
 
         '"${optCall}"'
-        '"${setVar}"'
+        '"${optVar}"'
     }'
 
     _argproc_positionalFuncs+=("_argproc:positional-${name}")
@@ -642,7 +642,7 @@ function process-args {
 #   array at the start of argument processing.
 function rest-arg {
     local optCall=''
-    local setVar=''
+    local optVar=''
 
     while (( $# > 0 )); do
         case "$1" in
@@ -650,7 +650,7 @@ function rest-arg {
                 optCall="${1#*=}"
                 ;;
             --var=?*)
-                setVar="${1#*=}"
+                optVar="${1#*=}"
                 ;;
             *)
                 # End of options / unrecognized option.
@@ -660,7 +660,7 @@ function rest-arg {
         shift
     done
 
-    if [[ ${optCall} == '' && ${setVar} == '' ]]; then
+    if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 'Must use at least one of --call or --var for rest argument.'
         return 1
     fi
@@ -670,15 +670,15 @@ function rest-arg {
         optCall="${optCall}"' "$@" || return "$?"'
     fi
 
-    if [[ ${setVar} != '' ]]; then
+    if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${setVar}=()")
-        setVar="${setVar}"'=("$@")'
+        _argproc_initStatements+=("${optVar}=()")
+        optVar="${optVar}"'=("$@")'
     fi
 
     eval 'function _argproc:rest {
         '"${optCall}"'
-        '"${setVar}"'
+        '"${optVar}"'
     }'
 }
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -116,7 +116,7 @@ function opt-action {
 #   be defaulted at the start of argument processing.
 function opt-choice {
     local optCall=''
-    local defaultValue=''
+    local optDefault=''
     local optVar=''
 
     local requiredName=''
@@ -129,7 +129,7 @@ function opt-choice {
                 optCall="${1#*=}"
                 ;;
             --default=*)
-                defaultValue="${1#*=}"
+                optDefault="${1#*=}"
                 ;;
             --required)
                 requiredName='?' # Gets replaced with a valid long name.
@@ -163,7 +163,7 @@ function opt-choice {
 
     if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${defaultValue}")")
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${optDefault}")")
         optVar="${optVar}"'="${_argproc_value}"'
     fi
 
@@ -337,7 +337,7 @@ function opt-toggle {
 #   argument processing.
 function opt-value {
     local optCall=''
-    local defaultValue=''
+    local optDefault=''
     local match=''
     local optVar=''
     local required=0
@@ -349,7 +349,7 @@ function opt-value {
                 optCall="${1#*=}"
                 ;;
             --default=*)
-                defaultValue="${1#*=}"
+                optDefault="${1#*=}"
                 ;;
             --match=?*)
                 match="${1#*=}"
@@ -387,7 +387,7 @@ function opt-value {
 
     if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${defaultValue}")")
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${optDefault}")")
         optVar="${optVar}"'="$1"'
     fi
 
@@ -442,7 +442,7 @@ function opt-value {
 #   causes the variable to be initialized at the start of argument processing.
 function positional-arg {
     local optCall=''
-    local defaultValue=''
+    local optDefault=''
     local match=''
     local optVar=''
     local required=0
@@ -454,7 +454,7 @@ function positional-arg {
                 optCall="${1#*=}"
                 ;;
             --default=*)
-                defaultValue="${1#*=}"
+                optDefault="${1#*=}"
                 ;;
             --match=?*)
                 match="${1#*=}"
@@ -492,7 +492,7 @@ function positional-arg {
 
     if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
-        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${defaultValue}")")
+        _argproc_initStatements+=("${optVar}=$(_argproc:quote "${optDefault}")")
         optVar="${optVar}"'="$1"'
     fi
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -572,22 +572,9 @@ function process-args {
 function rest-arg {
     local optCall=''
     local optVar=''
-
-    while (( $# > 0 )); do
-        case "$1" in
-            --call=?*)
-                optCall="${1#*=}"
-                ;;
-            --var=?*)
-                optVar="${1#*=}"
-                ;;
-            *)
-                # End of options / unrecognized option.
-                break
-                ;;
-        esac
-        shift
-    done
+    local args=("$@")
+    _argproc_janky-args call var \
+    || return 1
 
     if [[ ${optCall} == '' && ${optVar} == '' ]]; then
         echo 1>&2 'Must use at least one of --call or --var for rest argument.'

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -727,7 +727,6 @@ function _argproc_janky-args {
     :
 }
 
-
 # Builds up a list of statements to evaluate, based on the given arguments. It
 # is stored in the variable `_argproc_statements`, which is assumed to be
 # declared by its caller.

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -338,7 +338,7 @@ function opt-toggle {
 function opt-value {
     local optCall=''
     local optDefault=''
-    local match=''
+    local optMatch=''
     local optVar=''
     local optRequired=0
     local requiredSetter=''
@@ -352,7 +352,7 @@ function opt-value {
                 optDefault="${1#*=}"
                 ;;
             --match=?*)
-                match="${1#*=}"
+                optMatch="${1#*=}"
                 ;;
             --required)
                 optRequired=1
@@ -391,10 +391,10 @@ function opt-value {
         optVar="${optVar}"'="$1"'
     fi
 
-    if [[ ${match} != '' ]]; then
+    if [[ ${optMatch} != '' ]]; then
         # Re-form as the clause to insert to perform the check.
-        match='
-            elif ! [[ $1 =~ ^('"${match}"')$ ]]; then
+        optMatch='
+            elif ! [[ $1 =~ ^('"${optMatch}"')$ ]]; then
                 echo 1>&2 "Invalid value for option: --'"${name}"'"
                 echo 1>&2 "Value: $1"
                 return 1'
@@ -417,7 +417,7 @@ function opt-value {
         if (( $# < 1 )); then
             echo 1>&2 "Value required for option: --'"${name}"'"
             return 1
-        '"${match}"'
+        '"${optMatch}"'
         fi
 
         '"${optCall}"'
@@ -443,7 +443,7 @@ function opt-value {
 function positional-arg {
     local optCall=''
     local optDefault=''
-    local match=''
+    local optMatch=''
     local optVar=''
     local optRequired=0
     local ifMissing=''
@@ -457,7 +457,7 @@ function positional-arg {
                 optDefault="${1#*=}"
                 ;;
             --match=?*)
-                match="${1#*=}"
+                optMatch="${1#*=}"
                 ;;
             --required)
                 optRequired=1
@@ -496,10 +496,10 @@ function positional-arg {
         optVar="${optVar}"'="$1"'
     fi
 
-    if [[ ${match} != '' ]]; then
+    if [[ ${optMatch} != '' ]]; then
         # Re-form as the clause to insert to perform the check.
-        match='
-            elif ! [[ $1 =~ ^('"${match}"')$ ]]; then
+        optMatch='
+            elif ! [[ $1 =~ ^('"${optMatch}"')$ ]]; then
                 echo 1>&2 "Invalid value for argument <'"${name}"'>."
                 echo 1>&2 "Value: $1"
                 return 1'
@@ -517,7 +517,7 @@ function positional-arg {
     eval 'function _argproc:positional-'"${name}"' {
         if (( $# < 1 )); then
             '"${ifMissing}"'
-        '"${match}"'
+        '"${optMatch}"'
         fi
 
         '"${optCall}"'

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -779,7 +779,7 @@ function _argproc_janky-args {
             # Explicit end of options.
             args=()
             optsDone=1
-        elif [[ (${a} == '-') || (${a:0:0} != '-') ]]; then
+        elif [[ (${a} == '-') || (${a:0:1} != '-') ]]; then
             # Non-option argument.
             args=("${a}")
             optsDone=1

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -47,6 +47,16 @@ _argproc_preReturnStatements=()
 # --var=<name> -- Sets the global `<name>` to the configured action value, and
 #   causes it to be defaulted at the start of argument processing.
 function opt-action {
+    local optCall=''
+    local optDefaul=''
+    local optValue='1'
+    local optVar=''
+    local args=("$@")
+    _argproc_janky-args call default value var \
+    || return 1
+
+    # TODO: Convert the rest of this to deal with the new args stuff.
+
     local callFunc=''
     local defaultValue=0
     local setVar=''
@@ -705,6 +715,18 @@ function rest-arg {
 #
 # Library-internal functions
 #
+
+# Janky yet reasonable argument parser for the commands in this library. (How
+# meta!) Takes a list of option names to accept, each of which is parsed in a
+# standard way (e.g. `var` is always a variable name, etc.). Sets `opt<Name>`
+# (presumed to be a local variable declared in the calling scope) for each
+# parsed option. Assumes the variable `args` (again presumed local to the
+# caller) contains all the arguments, which gets updates by this function.
+function _argproc_janky-args {
+    # TODO
+    :
+}
+
 
 # Builds up a list of statements to evaluate, based on the given arguments. It
 # is stored in the variable `_argproc_statements`, which is assumed to be

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -228,28 +228,11 @@ function opt-choice {
 function opt-toggle {
     local optCall=''
     local optVar=''
+    local args=("$@")
+    _argproc_janky-args call var \
+    || return 1
 
-    ################################
-    ################################ CONVERT THIS ONE NEXT TO janky-args
-    ################################
-
-    while (( $# > 0 )); do
-        case "$1" in
-            --call=?*)
-                optCall="${1#*=}"
-                ;;
-            --var=?*)
-                optVar="${1#*=}"
-                ;;
-            *)
-                # End of options / unrecognized option.
-                break
-                ;;
-        esac
-        shift
-    done
-
-    local name="$1"
+    local name="${args[0]}"
 
     if ! [[ ${name} =~ ^([a-zA-Z0-9][-a-zA-Z0-9]*)(/[a-zA-Z0-9]?)?(/[a-zA-Z0-9])?$ ]]; then
         echo 1>&2 "Invalid option spec: ${name}"

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -395,36 +395,13 @@ function positional-arg {
     local optCall=''
     local optDefault=''
     local optMatch=''
-    local optVar=''
     local optRequired=0
-    local ifMissing=''
+    local optVar=''
+    local args=("$@")
+    _argproc_janky-args call default match required var \
+    || return 1
 
-    while (( $# > 0 )); do
-        case "$1" in
-            --call=?*)
-                optCall="${1#*=}"
-                ;;
-            --default=*)
-                optDefault="${1#*=}"
-                ;;
-            --match=?*)
-                optMatch="${1#*=}"
-                ;;
-            --required)
-                optRequired=1
-                ;;
-            --var=?*)
-                optVar="${1#*=}"
-                ;;
-            *)
-                # End of options / unrecognized option.
-                break
-                ;;
-        esac
-        shift
-    done
-
-    local name="$1"
+    local name="${args[0]}"
 
     if ! [[ ${name} =~ ^[a-zA-Z0-9][-a-zA-Z0-9]*$ ]]; then
         echo 1>&2 "Invalid argument spec: ${name}"
@@ -456,6 +433,7 @@ function positional-arg {
                 return 1'
     fi
 
+    local ifMissing=''
     if (( ${optRequired} )); then
         # Code to issue a complaint about the missing argument.
         ifMissing='

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -345,8 +345,7 @@ function opt-value {
         # Re-form as the clause to insert to perform the check.
         optMatch='
             elif ! [[ $1 =~ ^('"${optMatch}"')$ ]]; then
-                echo 1>&2 "Invalid value for option: --'"${name}"'"
-                echo 1>&2 "Value: $1"
+                echo 1>&2 "Invalid value for option --'"${name}"': $1"
                 return 1'
     fi
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -48,7 +48,7 @@ _argproc_preReturnStatements=()
 #   causes it to be defaulted at the start of argument processing.
 function opt-action {
     local optCall=''
-    local optDefaul=''
+    local optDefault=''
     local optValue='1'
     local optVar=''
     local args=("$@")
@@ -723,8 +723,71 @@ function rest-arg {
 # parsed option. Assumes the variable `args` (again presumed local to the
 # caller) contains all the arguments, which gets updates by this function.
 function _argproc_janky-args {
-    # TODO
-    :
+    local argError=0
+    local argSpecs=" $* "
+    local optsDone=0
+    local a
+
+    for a in "${args[@]}"; do
+        if (( optsDone )); then
+            args+=("${a}")
+            continue
+        fi
+
+        if [[ ${a} =~ --(.+) ]]; then
+            if ! [[ ${a} =~ ^--([a-z]+)(=.*)?$ ]]; then
+                echo 1>&2 "Invalid option syntax: ${a}"
+                return 1
+            fi
+
+            local name="${BASH_REMATCH[1]}"
+            local value="${BASH_REMATCH[2]}"
+
+            if ! [[ ${argSpecs} =~ " ${name} " ]]; then
+                echo 1>&2 "Unknown option: ${name}"
+                return 1
+            fi
+
+            case "${name}" in
+                call)
+                    [[ ${value} =~ ^=([-_a-zA-Z0-9]+)$ ]] \
+                    && optCall="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
+                default)
+                    [[ ${value} =~ ^=(.*)$ ]] \
+                    && optDefault="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
+                value)
+                    [[ ${value} =~ ^=(.*)$ ]] \
+                    && optValue="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
+                var)
+                    [[ ${value} =~ ^=([_a-zA-Z0-9]+)$ ]] \
+                    && optVar="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
+            esac
+
+            if (( argError )); then
+                echo 1>&2 "Invalid value for option --${name}."
+                return 1
+            fi
+        elif [[ ${a} == '--' ]]; then
+            # Explicit end of options.
+            args=()
+            optsDone=1
+        elif [[ (${a} == '-') || (${a:0:0} != '-') ]]; then
+            # Non-option argument.
+            args=("${a}")
+            optsDone=1
+        else
+            echo 1>&2 "Invalid option syntax: ${a}"
+            return 1
+        fi
+   done
 }
 
 # Builds up a list of statements to evaluate, based on the given arguments. It


### PR DESCRIPTION
This extracts a meta-arg-processor for the commands in `arg-processor`, and uses it. Whee!

It only net-saves ~ten lines, but it actually tightens up error checking a bit, and it also condenses much of argument processing into a single locus.