### PR TITLE
Rework `opt-action` "syntax."

### DIFF
--- a/bin/add-internet-gateway
+++ b/bin/add-internet-gateway
@@ -45,7 +45,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/add-ip-security-group-rules
+++ b/bin/add-ip-security-group-rules
@@ -59,7 +59,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Rule direction (`ingress` or `egress`).
 opt-choice --required --var=direction egress ingress

--- a/bin/add-subnets
+++ b/bin/add-subnets
@@ -47,7 +47,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/configure-security-group
+++ b/bin/configure-security-group
@@ -53,7 +53,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/delete-internet-gateway
+++ b/bin/delete-internet-gateway
@@ -41,7 +41,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/delete-security-group-rules
+++ b/bin/delete-security-group-rules
@@ -54,7 +54,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/delete-subnets
+++ b/bin/delete-subnets
@@ -48,7 +48,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/find-ami
+++ b/bin/find-ami
@@ -47,7 +47,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (availability zone).
 opt-value --required --var=inLocation in

--- a/bin/find-security-group
+++ b/bin/find-security-group
@@ -44,7 +44,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/find-vpc
+++ b/bin/find-vpc
@@ -42,7 +42,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/find-vpc-subnet
+++ b/bin/find-vpc-subnet
@@ -38,7 +38,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (availability zone).
 opt-value --required --var=inLocation in

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -56,35 +56,33 @@ _argproc_preReturnStatements=()
 # are unlikely to shadow globals. ("Hooray" for dynamic scoping!)
 #
 
-# Declares an "action" option, which takes no value on a commandline. No
-# `<value>` is allowed in the argument spec. If left unspecified, the default
-# variable value for an action option is `''` (the empty string).
-#
-# --value=<value> -- The value to use when indicating that the action is taken.
-#   If not specified, the action value is `1`.
+# Declares an "action" option, which takes no value on a commandline. If left
+# unspecified, the default variable value for an action option is `''` (the
+# empty string), and the default activation value is `1`.
 function opt-action {
     local optCall=''
     local optDefault=''
-    local optValue='1'
     local optVar=''
     local args=("$@")
-    _argproc_janky-args call default value var \
+    _argproc_janky-args call default var \
     || return 1
 
     local specName=''
     local specAbbrev=''
-    _argproc_parse-spec --abbrev "${args[0]}" \
+    local specHasValue=0
+    local specValue='1'
+    _argproc_parse-spec --abbrev --value "${args[0]}" \
     || return 1
 
     if [[ ${optCall} != '' ]]; then
         # Re-form as the caller code.
-        optCall="${optCall} $(_argproc:quote "${optValue}")"' || return "$?"'
+        optCall="${optCall} $(_argproc:quote "${specValue}")"' || return "$?"'
     fi
 
     if [[ ${optVar} != '' ]]; then
         # Set up the default initializer, and then re-form as the setter code.
         _argproc_initStatements+=("${optVar}=$(_argproc:quote "${optDefault}")")
-        optVar="${optVar}=$(_argproc:quote "${optValue}")"
+        optVar="${optVar}=$(_argproc:quote "${specValue}")"
     fi
 
     eval 'function _argproc:long-'"${specName}"' {
@@ -567,11 +565,6 @@ function _argproc_janky-args {
                 required)
                     [[ ${value} == '' ]] \
                     && optRequired=1 \
-                    || argError=1
-                    ;;
-                value)
-                    [[ ${value} =~ ^=(.*)$ ]] \
-                    && optValue="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
                 var)

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -57,11 +57,11 @@ _argproc_preReturnStatements=()
 #
 
 # Declares an "action" option, which takes no value on a commandline. If left
-# unspecified, the default variable value for an action option is `''` (the
-# empty string), and the default activation value is `1`.
+# unspecified, the default variable value for an action option is `0`, and the
+# default activation value is `1`.
 function opt-action {
     local optCall=''
-    local optDefault=''
+    local optDefault='0'
     local optVar=''
     local args=("$@")
     _argproc_janky-args call default var \
@@ -199,8 +199,8 @@ function opt-choice {
 # No `<value>` is allowed in the argument spec. The toggle state of off or on is
 # always indicated by a value of `0` or `1` (respectively). In addition to the
 # main long-form option `--<name>`, this function also defines `--no-<name>` to
-# turn the toggle off. If left unspecified, the default variable value for an
-# action option is `0`.
+# turn the toggle off. If left unspecified, the default variable value for a
+# toggle option is `0`.
 function opt-toggle {
     local optCall=''
     local optVar=''

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -659,7 +659,9 @@ function _argproc_parse-spec {
 
     if (( valueOk )); then
         specHasValue="$([[ ${value} == '' ]]; echo $?)"
-        specValue="${value:1}" # `:1` to drop the equal sign.
+        if (( specHasValue )); then
+            specValue="${value:1}" # `:1` to drop the equal sign.
+        fi
     elif [[ ${value} != '' ]]; then
         echo 1>&2 "Value not allowed in spec: ${spec}"
         return 1

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -74,7 +74,7 @@ else
 fi
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --match='[a-z][-a-z0-9]*' --var=inLocation in

--- a/bin/lib/cidr-calc
+++ b/bin/lib/cidr-calc
@@ -73,7 +73,7 @@ function usage {
 opt-choice --var=outputStyle --default=string json string
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Command.
 positional-arg --required --var=command command

--- a/bin/lib/filter-spec
+++ b/bin/lib/filter-spec
@@ -47,7 +47,7 @@ function usage {
 opt-choice --var=outputStyle --default=json compact json
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # List of filter specifications, as parallel arrays of name and value.
 filterNames=()

--- a/bin/lib/ip-permission-spec
+++ b/bin/lib/ip-permission-spec
@@ -40,7 +40,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Output style.
 opt-choice --var=outputStyle --default=json compact json

--- a/bin/lib/json-array
+++ b/bin/lib/json-array
@@ -40,7 +40,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Output style.
 opt-choice --var=outputStyle --default=json compact json

--- a/bin/lib/json-get
+++ b/bin/lib/json-get
@@ -50,7 +50,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Output style.
 opt-choice --var=outputStyle --default=json compact json lines raw words

--- a/bin/lib/json-length
+++ b/bin/lib/json-length
@@ -32,7 +32,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # JSON value.
 positional-arg --required --var=value json-value

--- a/bin/lib/json-val
+++ b/bin/lib/json-val
@@ -62,7 +62,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Input style.
 opt-choice --var=inputStyle --default=null-stdin null-stdin read-stdin slurp-stdin

--- a/bin/lib/name-tag-spec
+++ b/bin/lib/name-tag-spec
@@ -41,7 +41,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Output style.
 opt-choice --var=outputStyle --default=json compact json

--- a/bin/lib/now-stamp
+++ b/bin/lib/now-stamp
@@ -34,7 +34,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Suffix text.
 positional-arg --var=suffix --match='[-_:./a-zA-Z0-9]+' suffix

--- a/bin/lib/parse-location
+++ b/bin/lib/parse-location
@@ -52,7 +52,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Required input type.
 opt-choice --var=inputType --default=input-any \

--- a/bin/lib/region-from-location
+++ b/bin/lib/region-from-location
@@ -31,7 +31,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (availability zone or region).
 positional-arg --required --var=inLocation zone-or-region

--- a/bin/lib/region-from-zone
+++ b/bin/lib/region-from-zone
@@ -31,7 +31,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Availability zone.
 positional-arg --required --var=inZone zone

--- a/bin/list-availability-zones
+++ b/bin/list-availability-zones
@@ -42,7 +42,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/make-instance
+++ b/bin/make-instance
@@ -66,7 +66,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/make-security-group
+++ b/bin/make-security-group
@@ -49,7 +49,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (availability zone).
 opt-value --required --var=inLocation in

--- a/bin/make-vpc
+++ b/bin/make-vpc
@@ -39,7 +39,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in

--- a/bin/set-attributes
+++ b/bin/set-attributes
@@ -44,7 +44,7 @@ function usage {
 }
 
 # Want help?
-opt-action --call=usage --value=0 help/h
+opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in


### PR DESCRIPTION
This gets rid of `--value` on `opt-action`, replacing it with just using the `=<value>` part of an argument spec.