### PR TITLE
`--filter` not `--match` and with more functionality.

### DIFF
--- a/bin/add-internet-gateway
+++ b/bin/add-internet-gateway
@@ -51,13 +51,13 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name of the resulting gateway.
-opt-value --var=name --match='.+' name
+opt-value --var=name --filter='/./' name
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress
 
 # Name or ID of the VPC.
-opt-value --required --var=vpcNameOrId --match='.+' vpc
+opt-value --required --var=vpcNameOrId --filter='/./' vpc
 
 process-args "$@" || usage "$?"
 

--- a/bin/add-ip-security-group-rules
+++ b/bin/add-ip-security-group-rules
@@ -65,13 +65,13 @@ opt-action --call=usage help/h=0
 opt-choice --required --var=direction egress ingress
 
 # Name or ID of the security group.
-opt-value --required --var=groupNameOrId --match='.+' security-group
+opt-value --required --var=groupNameOrId --filter='/./' security-group
 
 # Location (region or availability zone).
 opt-value --required --var=inLocation in
 
 # Name of the rule.
-opt-value --var=name --match='.+' name
+opt-value --var=name --filter='/./' name
 
 # Port of the rule.
 opt-value --required --var=port --match='[0-9]+|all' port

--- a/bin/add-ip-security-group-rules
+++ b/bin/add-ip-security-group-rules
@@ -74,10 +74,10 @@ opt-value --required --var=inLocation in
 opt-value --var=name --filter='/./' name
 
 # Port of the rule.
-opt-value --required --var=port --match='[0-9]+|all' port
+opt-value --required --var=port --filter='/^([0-9]+|all)$/' port
 
 # Protocol of the rule.
-opt-value --required --var=protocol --match='all|tcp|udp' protocol
+opt-value --required --var=protocol --filter='/^(all|tcp|udp)$/' protocol
 
 # Quiet?
 opt-toggle --var=quiet quiet

--- a/bin/add-subnets
+++ b/bin/add-subnets
@@ -53,7 +53,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name for the subnets.
-opt-value --var=name --match='.+' name
+opt-value --var=name --filter='/./' name
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress
@@ -62,7 +62,7 @@ opt-toggle --call=progress-msg-switch progress
 opt-toggle --var=quiet quiet
 
 # Name or ID of the VPC.
-opt-value --required --var=vpcNameOrId --match='.+' vpc
+opt-value --required --var=vpcNameOrId --filter='/./' vpc
 
 process-args "$@" || usage "$?"
 

--- a/bin/configure-security-group
+++ b/bin/configure-security-group
@@ -59,10 +59,10 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name for the security group.
-opt-value --var=name --match='.+' name
+opt-value --var=name --filter='/./' name
 
 # Name or ID of the security group.
-opt-value --required --var=groupNameOrId --match='.+' security-group
+opt-value --required --var=groupNameOrId --filter='/./' security-group
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress

--- a/bin/delete-internet-gateway
+++ b/bin/delete-internet-gateway
@@ -47,7 +47,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # ID of the gateway.
-opt-value --required --var=gatewayId --match='.+' gateway
+opt-value --required --var=gatewayId --filter='/./' gateway
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress

--- a/bin/delete-security-group-rules
+++ b/bin/delete-security-group-rules
@@ -60,7 +60,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name or ID of the security group.
-opt-value --required --var=groupNameOrId --match='.+' security-group
+opt-value --required --var=groupNameOrId --filter='/./' security-group
 
 # Simple filter.
 opt-choice --var=simpleFilter \

--- a/bin/delete-subnets
+++ b/bin/delete-subnets
@@ -54,7 +54,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name or ID of the VPC.
-opt-value --required --var=vpcNameOrId --match='.+' vpc
+opt-value --required --var=vpcNameOrId --filter='/./' vpc
 
 # Simple filter for `--all` (degenerate choice option).
 opt-choice --var=simpleFilter \

--- a/bin/find-ami
+++ b/bin/find-ami
@@ -53,7 +53,8 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Instance type.
-opt-value --required --var=instanceType --match='[a-z0-9]+\.[a-z0-9]+' instance-type
+opt-value --required --var=instanceType \
+    --filter='/^[a-z0-9]+\.[a-z0-9]+$/' instance-type
 
 process-args "$@" || usage "$?"
 

--- a/bin/find-vpc-subnet
+++ b/bin/find-vpc-subnet
@@ -44,7 +44,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name or ID of VPC to look up.
-opt-value --required --var=nameOrId --match='.+' vpc
+opt-value --required --var=nameOrId --filter='/./' vpc
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -29,6 +29,13 @@
 # itself optionally specified via `--default=<value>`. If `--default` isn't
 # used, then the default-for-the-default depends on the specific function.
 #
+# Definers for value-accepting arguments take an option `--match=<regex>`, which
+# specifies a regular expression matched against the entire argument value. If
+# the match fails, the argument isn't accepted.
+#
+# Some argument-definers also accept `--required`, to indicate that the argument
+# or option is required (mandatory).
+#
 # Beyond the above, see the docs for the functions for restrictions and
 # additional options.
 
@@ -86,10 +93,8 @@ function opt-action {
 # Declares a "choice" option set, consisting of one or more options. On a
 # commandline, no choice option accepts a value (because the option name itself
 # implies the value). If left unspecified, the default variable value for a
-# choice option is `''` (the empty string).
-#
-# --required -- Indicates that one of the options defined by this set must be
-#   passed.
+# choice option is `''` (the empty string). This definer also accepts the
+# `--required` option.
 function opt-choice {
     local optCall=''
     local optDefault=''
@@ -165,11 +170,8 @@ function opt-toggle {
 # Declares a "value" option, which requires a value when passed on a
 # commandline. No `<abbrev>` or `<value>` is allowed in the argument spec. If
 # left unspecified, the default variable value for a value option is `''` (the
-# empty string).
-#
-# --match=<regex> -- Regular expression matched against the entire argument
-#   value. If the value does not match, then the option gets rejected.
-# --required -- Indicates that this option must be passed.
+# empty string). This definer also accepts the `--required` and `--match`
+# options.
 function opt-value {
     local optCall=''
     local optDefault=''
@@ -199,11 +201,8 @@ function opt-value {
 
 # Declares a positional argument. No `<abbrev>` or `<value>` is allowed in the
 # argument spec. Unlike options, a positional argument name is _only_ used for
-# error messages and internal bookkeeping.
-#
-# --match=<regex> -- Regular expression matched against the entire argument
-#   value. If the value does not match, then the argument gets rejected.
-# --required -- Indicates that this argument must be passed.
+# error messages and internal bookkeeping. This definer also accepts the
+# `--required` and `--match` options.
 function positional-arg {
     local optCall=''
     local optDefault=''

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -487,9 +487,9 @@ function _argproc_define-value-required-arg {
 # Adds a pre-return check which fails if none of the indicated arguments/options
 # were present on the commandline.
 function _argproc_add-required-arg-postcheck {
-    local kind='argument'
+    local isOption=0
     if [[ $1 == '--option' ]]; then
-        kind='option'
+        isOption=1
         shift
     fi
 
@@ -507,14 +507,24 @@ function _argproc_add-required-arg-postcheck {
     done
     checkClause+=' ]]'
 
-    local errorMsg="Missing required ${kind}"
+    local errorMsg='Missing required '
+    local argNames
+
+    if (( isOption )); then
+        errorMsg+='option'
+        argNames="$(printf ' --%s' "$@")"
+    else
+        errorMsg+='argument'
+        argNames="$*"
+    fi
+
     if (( $# > 1 )); then
         errorMsg+=' from set'
     fi
 
     _argproc_preReturnStatements+=(
         "$(printf $'%s || { echo 1>&2 %s %s; false; }\n' \
-            "${checkClause}" "${errorMsg}:" "$(printf ' --%s' "$@")"
+            "${checkClause}" "${errorMsg}:" "$argNames"
     )")
 }
 

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -170,22 +170,17 @@ function opt-toggle {
 # Declares a "value" option, which requires a value when passed on a
 # commandline. No `<abbrev>` or `<value>` is allowed in the argument spec. If
 # left unspecified, the default variable value for a value option is `''` (the
-# empty string). This definer also accepts the `--required` and `--match`
+# empty string). This definer also accepts the `--required` and `--filter`
 # options.
 function opt-value {
     local optCall=''
     local optDefault=''
     local optFilter=''
-    local optMatch=''
     local optRequired=0
     local optVar=''
     local args=("$@")
-    _argproc_janky-args call default filter match required var \
+    _argproc_janky-args call default filter required var \
     || return 1
-
-    if [[ ${optMatch} != '' ]]; then
-        optFilter="/^(${optMatch})\$/"
-    fi
 
     local specName=''
     _argproc_parse-spec "${args[0]}" \
@@ -207,21 +202,16 @@ function opt-value {
 # Declares a positional argument. No `<abbrev>` or `<value>` is allowed in the
 # argument spec. Unlike options, a positional argument name is _only_ used for
 # error messages and internal bookkeeping. This definer also accepts the
-# `--required` and `--match` options.
+# `--required` and `--filter` options.
 function positional-arg {
     local optCall=''
     local optDefault=''
     local optFilter=''
-    local optMatch=''
     local optRequired=0
     local optVar=''
     local args=("$@")
-    _argproc_janky-args call default filter match required var \
+    _argproc_janky-args call default filter required var \
     || return 1
-
-    if [[ ${optMatch} != '' ]]; then
-        optFilter="/^(${optMatch})\$/"
-    fi
 
     local specName=''
     _argproc_parse-spec "${args[0]}" \
@@ -583,11 +573,6 @@ function _argproc_janky-args {
                 filter)
                     [[ ${value} =~ ^=(/(.*)/|[_a-zA-Z][-_:a-zA-Z0-9]*)$ ]] \
                     && optFilter="${BASH_REMATCH[1]}" \
-                    || argError=1
-                    ;;
-                match)
-                    [[ ${value} =~ ^=(.*)$ ]] \
-                    && optMatch="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
                 required)

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -29,9 +29,11 @@
 # itself optionally specified via `--default=<value>`. If `--default` isn't
 # used, then the default-for-the-default depends on the specific function.
 #
-# Definers for value-accepting arguments take an option `--match=<regex>`, which
-# specifies a regular expression matched against the entire argument value. If
-# the match fails, the argument isn't accepted.
+# Definers for value-accepting arguments take an option `--filter=<spec>`, which
+# specifies either a function to call or a regular expression to match against
+# the argument value. If the call or match fails, the argument isn't accepted.
+# In addition, the function form is expected to output the value to use on
+# success (e.g. a replacement for what was directly passed on the commandline).
 #
 # Some argument-definers also accept `--required`, to indicate that the argument
 # or option is required (mandatory).

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -175,12 +175,17 @@ function opt-toggle {
 function opt-value {
     local optCall=''
     local optDefault=''
+    local optFilter=''
     local optMatch=''
     local optRequired=0
     local optVar=''
     local args=("$@")
-    _argproc_janky-args call default match required var \
+    _argproc_janky-args call default filter match required var \
     || return 1
+
+    if [[ ${optMatch} != '' ]]; then
+        optFilter="/^(${optMatch})\$/"
+    fi
 
     local specName=''
     _argproc_parse-spec "${args[0]}" \
@@ -192,7 +197,7 @@ function opt-value {
     fi
 
     _argproc_define-value-required-arg --option \
-        "${specName}" "${optCall}" "${optVar}" "${optMatch}"
+        "${specName}" "${optCall}" "${optVar}" "${optFilter}"
 
     if (( optRequired )); then
         _argproc_add-required-arg-postcheck --option "${specName}"
@@ -206,12 +211,17 @@ function opt-value {
 function positional-arg {
     local optCall=''
     local optDefault=''
+    local optFilter=''
     local optMatch=''
     local optRequired=0
     local optVar=''
     local args=("$@")
-    _argproc_janky-args call default match required var \
+    _argproc_janky-args call default filter match required var \
     || return 1
+
+    if [[ ${optMatch} != '' ]]; then
+        optFilter="/^(${optMatch})\$/"
+    fi
 
     local specName=''
     _argproc_parse-spec "${args[0]}" \
@@ -223,7 +233,7 @@ function positional-arg {
     fi
 
     _argproc_define-value-required-arg \
-        "${specName}" "${optCall}" "${optVar}" "${optMatch}"
+        "${specName}" "${optCall}" "${optVar}" "${optFilter}"
 
     if (( optRequired )); then
         _argproc_add-required-arg-postcheck "${specName}"
@@ -423,7 +433,7 @@ function _argproc_define-value-required-arg {
     local longName="$1"
     local callFunc="$2"
     local varName="$3"
-    local matchExpr="$4"
+    local filter="$4"
 
     local desc handlerName
     if (( isOption )); then
@@ -436,29 +446,34 @@ function _argproc_define-value-required-arg {
 
     if [[ ${callFunc} != '' ]]; then
         # Re-form as the caller code.
-        callFunc="${callFunc}"' "$1" || return "$?"'
+        callFunc="${callFunc}"' "${_argproc_value}" || return "$?"'
     fi
 
     if [[ ${varName} != '' ]]; then
         # Re-form as the setter code.
-        varName="${varName}"'="$1"'
+        varName="${varName}"'="${_argproc_value}"'
     fi
 
-    if [[ ${matchExpr} != '' ]]; then
-        # Re-form as the clause to insert to perform the check.
-        matchExpr='
-            elif ! [[ $1 =~ ^('"${matchExpr}"')$ ]]; then
-                echo 1>&2 "Invalid value for '"${desc}"': $1"
-                return 1'
+    if [[ ${filter} =~ ^/(.*)/$ ]]; then
+        # Re-form `filter` as the statement which performs the regex check.
+        filter="${BASH_REMATCH[1]}"
+        filter='
+            if ! [[ ${_argproc_value} =~ '"${filter}"' ]]; then
+                echo 1>&2 "Invalid value for '"${desc}"': ${_argproc_value}"
+                return 1
+            fi'
+    elif [[ ${filter} != '' ]]; then
+        # Re-form `filter` as the call to the filter function.
+        filter='_argproc_value="$('"${filter}"' "${_argproc_value}")" || return 1'
     fi
 
     eval 'function '"${handlerName}"' {
         if (( $# < 1 )); then
             echo 1>&2 "Value required for '"${desc}"'."
             return 1
-        '"${matchExpr}"'
         fi
-
+        local _argproc_value="$1"
+        '"${filter}"'
         '"${callFunc}"'
         '"${varName}"'
         _argproc_receivedArgNames+="<'"${longName}"'>"
@@ -546,13 +561,18 @@ function _argproc_janky-args {
 
             case "${name}" in
                 call)
-                    [[ ${value} =~ ^=([-_a-zA-Z][-_a-zA-Z0-9]*)$ ]] \
+                    [[ ${value} =~ ^=([_a-zA-Z][-_:a-zA-Z0-9]*)$ ]] \
                     && optCall="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
                 default)
                     [[ ${value} =~ ^=(.*)$ ]] \
                     && optDefault="${BASH_REMATCH[1]}" \
+                    || argError=1
+                    ;;
+                filter)
+                    [[ ${value} =~ ^=(/(.*)/|[_a-zA-Z][-_:a-zA-Z0-9]*)$ ]] \
+                    && optFilter="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
                 match)

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -77,7 +77,7 @@ fi
 opt-action --call=usage help/h=0
 
 # Location (region or availability zone).
-opt-value --match='[a-z][-a-z0-9]*' --var=inLocation in
+opt-value --filter='/^[a-z][-a-z0-9]*$/' --var=inLocation in
 
 # File to print the constructed command to.
 opt-value --filter='/./' --var=printCommandTo print-command-to

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -80,7 +80,7 @@ opt-action --call=usage help/h=0
 opt-value --match='[a-z][-a-z0-9]*' --var=inLocation in
 
 # File to print the constructed command to.
-opt-value --match='.+' --var=printCommandTo print-command-to
+opt-value --filter='/./' --var=printCommandTo print-command-to
 
 # Just print argument "skeleton" ?
 opt-action --var=skeleton skeleton

--- a/bin/lib/ip-permission-spec
+++ b/bin/lib/ip-permission-spec
@@ -25,7 +25,8 @@ function usage {
     Constructs and prints a JSON object suitable for use as an
     `IpPermissions` entry to one of the security group rule addition
     commands. <protocol> must be one of `all`, `tcp`, or `udp`. The resulting
-    specification contains both IPv4 and IPv6 entries.
+    specification contains both IPv4 and IPv6 entries. <port> must be a valid
+    port number or `all`.
 
     --compact
       Output in compact (not multiline) JSON form.

--- a/bin/lib/ip-permission-spec
+++ b/bin/lib/ip-permission-spec
@@ -47,10 +47,10 @@ opt-action --call=usage help/h=0
 opt-choice --var=outputStyle --default=json compact json
 
 # Protocol.
-positional-arg --required --var=protocol --match='all|tcp|udp' protocol
+positional-arg --required --var=protocol --filter='/^(all|tcp|udp)$/' protocol
 
 # Port.
-positional-arg --required --var=port --match='[0-9]+|all' port
+positional-arg --required --var=port --filter='/^([0-9]+|all)$/' port
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/name-tag-spec
+++ b/bin/lib/name-tag-spec
@@ -47,7 +47,7 @@ opt-action --call=usage help/h=0
 opt-choice --var=outputStyle --default=json compact json
 
 # Resource type.
-positional-arg --required --var=resourceType --match='[-a-z0-9]+' resource-type
+positional-arg --required --var=resourceType --filter='/^[-a-z0-9]+$/' resource-type
 
 # Name for the resource.
 positional-arg --required --var=name --filter='/./' name

--- a/bin/lib/name-tag-spec
+++ b/bin/lib/name-tag-spec
@@ -50,7 +50,7 @@ opt-choice --var=outputStyle --default=json compact json
 positional-arg --required --var=resourceType --match='[-a-z0-9]+' resource-type
 
 # Name for the resource.
-positional-arg --required --var=name --match='.+' name
+positional-arg --required --var=name --filter='/./' name
 
 process-args "$@" || usage "$?"
 

--- a/bin/lib/now-stamp
+++ b/bin/lib/now-stamp
@@ -37,7 +37,7 @@ function usage {
 opt-action --call=usage help/h=0
 
 # Suffix text.
-positional-arg --var=suffix --match='[-_:./a-zA-Z0-9]+' suffix
+positional-arg --var=suffix --filter='/^[-_:./a-zA-Z0-9]+$/' suffix
 
 process-args "$@" || usage "$?"
 

--- a/bin/make-instance
+++ b/bin/make-instance
@@ -75,7 +75,7 @@ opt-value --required --var=inLocation in
 opt-value --var=instanceType --default='t3.nano' instance-type
 
 # Name for the SSH keypair that allows for login access.
-opt-value --var=keyName --match='.*' key-name
+opt-value --var=keyName --filter='/./' key-name
 
 # Name for the instance.
 opt-value --var=name --filter='/./' name
@@ -84,10 +84,10 @@ opt-value --var=name --filter='/./' name
 opt-value --var=groupNameOrId --filter='/./' security-group
 
 # Actual user data (first-boot script).
-opt-value --var=userData --match='.*' user-data
+opt-value --var=userData --filter='/./' user-data
 
 # Name of file containing user data.
-opt-value --var=userDataFile --match='.*' user-data-file
+opt-value --var=userDataFile --filter='/./' user-data-file
 
 # Name or ID of the VPC to be in.
 opt-value --var=vpcNameOrId --filter='/./' vpc

--- a/bin/make-instance
+++ b/bin/make-instance
@@ -78,10 +78,10 @@ opt-value --var=instanceType --default='t3.nano' instance-type
 opt-value --var=keyName --match='.*' key-name
 
 # Name for the instance.
-opt-value --var=name --match='.+' name
+opt-value --var=name --filter='/./' name
 
 # Name or ID of the security group to be in.
-opt-value --var=groupNameOrId --match='.+' security-group
+opt-value --var=groupNameOrId --filter='/./' security-group
 
 # Actual user data (first-boot script).
 opt-value --var=userData --match='.*' user-data
@@ -90,7 +90,7 @@ opt-value --var=userData --match='.*' user-data
 opt-value --var=userDataFile --match='.*' user-data-file
 
 # Name or ID of the VPC to be in.
-opt-value --var=vpcNameOrId --match='.+' vpc
+opt-value --var=vpcNameOrId --filter='/./' vpc
 
 process-args "$@" || usage "$?"
 

--- a/bin/make-security-group
+++ b/bin/make-security-group
@@ -55,10 +55,10 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Description of the resulting security group.
-opt-value --var=description --match='.*' description
+opt-value --var=description --filter='/./' description
 
 # Name for the resulting security group.
-opt-value --var=name --match='.*' name
+opt-value --var=name --filter='/^[-_a-zA-Z0-9]+$/' name
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress

--- a/bin/make-security-group
+++ b/bin/make-security-group
@@ -64,7 +64,7 @@ opt-value --var=name --match='.*' name
 opt-toggle --call=progress-msg-switch progress
 
 # Name or ID of VPC to look up.
-opt-value --required --var=vpcNameOrId --match='.+' vpc
+opt-value --required --var=vpcNameOrId --filter='/./' vpc
 
 process-args "$@" || usage "$?"
 

--- a/bin/make-vpc
+++ b/bin/make-vpc
@@ -45,7 +45,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # Name for the resulting VPC.
-opt-value --required --var=name --match='.*' name
+opt-value --required --var=name --filter='/^[-_a-zA-Z0-9]+$/' name
 
 process-args "$@" || usage "$?"
 

--- a/bin/set-attributes
+++ b/bin/set-attributes
@@ -50,7 +50,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # ID of the thing to operate on.
-opt-value --required --var=id --match='.*' id
+opt-value --required --var=id --match='/^[-a-z0-9]+$/' id
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress

--- a/bin/set-attributes
+++ b/bin/set-attributes
@@ -50,7 +50,7 @@ opt-action --call=usage help/h=0
 opt-value --required --var=inLocation in
 
 # ID of the thing to operate on.
-opt-value --required --var=id --match='/^[-a-z0-9]+$/' id
+opt-value --required --var=id --filter='/^[-a-z0-9]+$/' id
 
 # Progress messages?
 opt-toggle --call=progress-msg-switch progress


### PR DESCRIPTION
This changes the option `--match` to be `--filter`, and expands it to indicate either a regex to match or a function to call to perform filtering. All use sites were changed, but no function-calling sites were added in this PR.