### PR TITLE
Exactly one argument

### DIFF
--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -359,6 +359,28 @@ function rest-arg {
 # Library-internal functions
 #
 
+# Gets the description of the named argument.
+function _argproc_arg-description {
+    local short=0
+    if [[ $1 == '--short' ]]; then
+        short=1
+        shift
+    fi
+
+    local longName="$1"
+    local funcName="_argproc:arg-description-${longName}"
+    local desc
+
+    desc="$("${funcName}")" \
+    || return 1
+
+    if (( short )); then
+        echo "${desc/* /}"
+    else
+        echo "${desc}"
+    fi
+}
+
 # Defines an "abbrev" function, which is what gets called to activate a
 # short-form option.
 function _argproc_define-abbrev {
@@ -388,6 +410,9 @@ function _argproc_define-no-value-arg {
     local value="$5"
 
     value="$(_argproc:quote "${value}")"
+
+    _argproc_set-arg-description "${longName}" option \
+    || return 1
 
     if [[ ${callFunc} != '' ]]; then
         # Re-form as the caller code.
@@ -430,9 +455,11 @@ function _argproc_define-value-required-arg {
 
     local desc handlerName
     if (( isOption )); then
+        _argproc_set-arg-description "${longName}" option || return 1
         desc="option --${longName}"
         handlerName="_argproc:long-${longName}"
     else
+        _argproc_set-arg-description "${longName}" argument || return 1
         desc="argument <${longName}>"
         handlerName="_argproc:positional-${longName}"
     fi
@@ -500,24 +527,29 @@ function _argproc_add-required-arg-postcheck {
     done
     checkClause+=' ]]'
 
-    local errorMsg='Missing required '
-    local argNames
-
-    if (( isOption )); then
-        errorMsg+='option'
-        argNames="$(printf ' --%s' "$@")"
+    local errorMsg
+    if (( $# == 1 )); then
+        errorMsg="Missing required $(_argproc_arg-description "$1")."
     else
-        errorMsg+='argument'
-        argNames="$*"
-    fi
-
-    if (( $# > 1 )); then
-        errorMsg+=' from set'
+        local allOptions=1
+        errorMsg=''
+        for longName in "$@"; do
+            local desc="$(_argproc_arg-description --short "${longName}")"
+            if ! [[ ${desc} =~ - ]]; then
+                allOptions=0
+            fi
+            errorMsg+=" ${desc}"
+        done
+        if (( allOptions )); then
+            errorMsg="Missing required option from set:${errorMsg}"
+        else
+            errorMsg="Missing required argument from set:${errorMsg}"
+        fi
     fi
 
     _argproc_preReturnStatements+=(
-        "$(printf $'%s || { echo 1>&2 %s %s; false; }\n' \
-            "${checkClause}" "${errorMsg}:" "$argNames"
+        "$(printf $'%s || { echo 1>&2 %q; false; }\n' \
+            "${checkClause}" "${errorMsg}"
     )")
 }
 
@@ -675,6 +707,38 @@ function _argproc_parse-spec {
         echo 1>&2 "Value not allowed in spec: ${spec}"
         return 1
     fi
+}
+
+# Sets the description of the named argument based on its type. This function
+# will fail if an argument with the given name was already defined.
+function _argproc_set-arg-description {
+    local longName="$1"
+    local typeName="$2"
+
+    local funcName="_argproc:arg-description-${longName}"
+
+    if declare -F "${funcName}" >/dev/null; then
+        echo 1>&2 "Duplicate argument: ${longName}"
+        return 1
+    fi
+
+    local desc
+    case "${typeName}" in
+        argument)
+            desc="argument <${longName}>"
+            ;;
+        option)
+            desc="option --${longName}"
+            ;;
+        *)
+            echo 1>&2 "Unknown type: ${typeName}"
+            return 1
+            ;;
+    esac
+
+    eval 'function '"${funcName}"' {
+        echo '"$(_argproc:quote "${desc}")"'
+    }'
 }
 
 # Builds up a list of statements to evaluate, based on the given arguments. It

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -135,7 +135,7 @@ function opt-choice {
     done
 
     if (( optRequired )); then
-        _argproc_add-required-arg-postcheck --option "${allNames[@]}"
+        _argproc_add-required-arg-postcheck "${allNames[@]}"
     fi
 }
 
@@ -200,7 +200,7 @@ function opt-value {
         "${specName}" "${optCall}" "${optVar}" "${optFilter}"
 
     if (( optRequired )); then
-        _argproc_add-required-arg-postcheck --option "${specName}"
+        _argproc_add-required-arg-postcheck "${specName}"
     fi
 }
 
@@ -507,12 +507,6 @@ function _argproc_define-value-required-arg {
 # Adds a pre-return check which fails if none of the indicated arguments/options
 # were present on the commandline.
 function _argproc_add-required-arg-postcheck {
-    local isOption=0
-    if [[ $1 == '--option' ]]; then
-        isOption=1
-        shift
-    fi
-
     local checkClause='[[ '
     local longName
     local first=1

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -327,6 +327,25 @@ function process-args {
     return "${_argproc_error}"
 }
 
+# Requires that exactly one of the indicated arguments / options is present.
+function require-exactly-one-arg-of {
+    local args=("$@")
+    _argproc_janky-args --multi-spec \
+    || return 1
+
+    local allNames=()
+    local spec
+    for spec in "${args[@]}"; do
+        local specName=''
+        _argproc_parse-spec "${spec}" \
+        || return 1
+
+        allNames+=("${specName}")
+    done
+
+    _argproc_add-required-arg-postcheck --exactly-one "${allNames[@]}"
+}
+
 # Declares a "rest" argument, which gets all the non-option and non-positional
 # arguments, during parsing. If this is not declared, argument processing will
 # report an error in the presence of any "rest" arguments.
@@ -505,45 +524,54 @@ function _argproc_define-value-required-arg {
 }
 
 # Adds a pre-return check which fails if none of the indicated arguments/options
-# were present on the commandline.
+# was present on the commandline, and optionally if more than exactly one was
+# present.
 function _argproc_add-required-arg-postcheck {
-    local checkClause='[[ '
+    local exactlyOne=0
+    if [[ $1 == '--exactly-one' ]]; then
+        exactlyOne=1
+        shift
+    fi
+
+    _argproc_preReturnStatements+=('local _argproc_count=0')
+
+    local argNoun='option'
+    local allNames=''
+
     local longName
-    local first=1
     for longName in "$@"; do
-        if (( first )); then
-            first=0
-        else
-            checkClause+=' || '
+        _argproc_preReturnStatements+=("$(
+            printf '[[ ${_argproc_receivedArgNames} =~ "<%s>" ]] && (( _argproc_count++ )) || true' \
+                "${longName}"
+        )")
+
+        local desc="$(_argproc_arg-description --short "${longName}")"
+        if ! [[ ${desc} =~ - ]]; then
+            argNoun='argument'
         fi
-        checkClause+="$(
-            printf '${_argproc_receivedArgNames} =~ "<%s>"' "${longName}")"
+
+        allNames+=" ${desc}"
     done
-    checkClause+=' ]]'
 
     local errorMsg
+
+    if (( exactlyOne )); then
+        errorMsg="Too many ${argNoun}s from set:${allNames}"
+        _argproc_preReturnStatements+=("$(
+            printf '(( _argproc_count <= 1 )) || { echo 1>&2 %q; false; }' \
+                "${errorMsg}"
+        )")
+    fi
+
     if (( $# == 1 )); then
-        errorMsg="Missing required $(_argproc_arg-description "$1")."
+        errorMsg="Missing required ${argNoun}${allNames}."
     else
-        local allOptions=1
-        errorMsg=''
-        for longName in "$@"; do
-            local desc="$(_argproc_arg-description --short "${longName}")"
-            if ! [[ ${desc} =~ - ]]; then
-                allOptions=0
-            fi
-            errorMsg+=" ${desc}"
-        done
-        if (( allOptions )); then
-            errorMsg="Missing required option from set:${errorMsg}"
-        else
-            errorMsg="Missing required argument from set:${errorMsg}"
-        fi
+        errorMsg="Missing required ${argNoun} from set:${allNames}"
     fi
 
     _argproc_preReturnStatements+=(
-        "$(printf $'%s || { echo 1>&2 %q; false; }\n' \
-            "${checkClause}" "${errorMsg}"
+        "$(printf $'(( _argproc_count != 0 )) || { echo 1>&2 %q; false; }\n' \
+            "${errorMsg}"
     )")
 }
 

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -66,7 +66,7 @@ argError=0
 # AWS command and subcommand. These are expected before any dashed options.
 if ! ( (( $# >= 2 )) && [[ $1 =~ ^[a-z] ]] && [[ $2 =~ ^[a-z] ]] ); then
     echo 1>&2 'Missing AWS command and/or subcommand.'
-    argError=1
+    usage 1
 else
     command="$1"
     subcommand="$2"
@@ -84,6 +84,8 @@ opt-value --filter='/./' --var=printCommandTo print-command-to
 
 # Just print argument "skeleton" ?
 opt-action --var=skeleton skeleton
+
+require-exactly-one-arg-of in skeleton
 
 # Output style (result post-processor option).
 outputStyle=normal
@@ -147,13 +149,6 @@ function parse-rest {
 }
 
 process-args "$@" || usage "$?"
-
-if [[ ${inRegion} == '' ]] && (( !skeleton )); then
-    # TODO: Maybe there should be something like `opt-require-one skeleton in`
-    # which could be called to declare this kind of requirement.
-    echo 1>&2 'Missing option: --in or --skeleton'
-    usage 1
-fi
 
 
 #

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -34,15 +34,16 @@ function usage {
       The AWS command and subcommand to call, e.g. `ec2 run-instances`.
 
     --in=<region-or-zone>
-      What region to make the call in. Must be specified. If specified as
-      an availability zone, only the region portion matters.
+      What region to make the call in. If specified as an availability zone,
+      only the region portion matters. Either this option or `--skeleton` must
+      be specified.
     --print-command-to=<file>
       Name of a file to print the fully-constructed command to. It is
       emitted as a JSON value including both split-out components and
       the actual commandline.
     --skeleton
-      Print out a JSON "skeleton" of parameters. This can be filtered just
-      like any other result.
+      Instead of making a regular call, just print out a JSON "skeleton" of the
+      parameters to the command. This can be filtered just like any other result.
 
     Output options:
 


### PR DESCRIPTION
[This is perhaps getting into gilded-lily territory, but anyhoo…]

This PR adds `require-exactly-one-arg-of` to `arg-processor`, and uses it productively in `aws-json`. I _think_ this is going to be the last addition to `arg-processor` for a bit, though it still needs a little cleanup pass.