### PR TITLE
`opt-enum` with first uses

### DIFF
--- a/bin/add-internet-gateway
+++ b/bin/add-internet-gateway
@@ -94,7 +94,7 @@ function figure-out-name {
 vpcInfo="$(lib find-vpc --print-all --loc="${region}" "${vpcNameOrId}")" \
 || exit "$?"
 
-vpcId="$(jget --raw "${vpcInfo}" '.VpcId')"
+vpcId="$(jget --output=raw "${vpcInfo}" '.VpcId')"
 usesIpv4="$(jget "${vpcInfo}" \
     'if .CidrBlockAssociationSet == null then 0 else 1 end')"
 usesIpv6="$(jget "${vpcInfo}" \

--- a/bin/add-subnets
+++ b/bin/add-subnets
@@ -213,5 +213,5 @@ fi
 progress-msg "Done making and configuring ${#results[@]} subnets."
 
 if (( !quiet )); then
-    jarray --strings "${results[@]}"
+    jarray --input=strings "${results[@]}"
 fi

--- a/bin/add-subnets
+++ b/bin/add-subnets
@@ -78,9 +78,9 @@ azList=($(lib list-availability-zones --loc="${region}")) \
 vpcInfo="$(lib find-vpc --loc="${region}" --print-all "${vpcNameOrId}")" \
 || exit "$?"
 
-vpcId="$(jget --raw "${vpcInfo}" '.VpcId')"
+vpcId="$(jget --output=raw "${vpcInfo}" '.VpcId')"
 
-cidr4="$(jget --raw "${vpcInfo}" '
+cidr4="$(jget --output=raw "${vpcInfo}" '
     .CidrBlockAssociationSet
     |
     if length == 0 then "none"
@@ -94,7 +94,7 @@ if [[ ${cidr4} == 'many' ]]; then
     exit 1
 fi
 
-cidr6="$(jget --raw "${vpcInfo}" '
+cidr6="$(jget --output=raw "${vpcInfo}" '
     .Ipv6CidrBlockAssociationSet
     |
     if length == 0 then "none"

--- a/bin/configure-security-group
+++ b/bin/configure-security-group
@@ -80,8 +80,8 @@ groupInfo="$(
 )" \
 || exit "$?"
 
-groupId="$(jget --raw "${groupInfo}" '.GroupId')"
-groupName="$(jget --raw "${groupInfo}" '.GroupName')"
+groupId="$(jget --output=raw "${groupInfo}" '.GroupId')"
+groupName="$(jget --output=raw "${groupInfo}" '.GroupName')"
 
 if [[ ${name} == '' ]]; then
     name="${groupName}"

--- a/bin/delete-internet-gateway
+++ b/bin/delete-internet-gateway
@@ -72,7 +72,7 @@ gatewayInfo="$(ec2-json describe-internet-gateways \
 
 # Find the attached VPC ID if any. And if there is a VPC, figure out what needs
 # to be done to detach it.
-vpcId="$(jget --raw "${gatewayInfo}" '.Attachments[0].VpcId')"
+vpcId="$(jget --output=raw "${gatewayInfo}" '.Attachments[0].VpcId')"
 rtId=
 attached=0
 hasIpv4Route=0
@@ -89,7 +89,7 @@ if [[ ${vpcId} != 'null' ]]; then
     )" \
     || exit "$?"
 
-    rtId="$(jget --raw "${rtInfo}" '.RouteTableId')"
+    rtId="$(jget --output=raw "${rtInfo}" '.RouteTableId')"
 
     hasIpv4Route="$(jget "${rtInfo}" '
           .Routes

--- a/bin/delete-security-group-rules
+++ b/bin/delete-security-group-rules
@@ -109,13 +109,13 @@ selectedRules="$(
 || exit "$?"
 
 egressRuleIds="$(
-    jval <<<"${selectedRules}" --slurp-stdin \
+    jval <<<"${selectedRules}" --input=slurp \
         'map(select(.IsEgress == true) | .SecurityGroupRuleId)'
 )" \
 || exit "$?"
 
 ingressRuleIds="$(
-    jval <<<"${selectedRules}" --slurp-stdin \
+    jval <<<"${selectedRules}" --input=slurp \
         'map(select(.IsEgress == false) | .SecurityGroupRuleId)'
 )" \
 || exit "$?"

--- a/bin/delete-security-group-rules
+++ b/bin/delete-security-group-rules
@@ -104,7 +104,7 @@ allRules="$(ec2-json describe-security-group-rules \
 || exit "$?"
 
 selectedRules="$(
-    jval <<<"${allRules}" --read-stdin -- "${filterArgs[@]}"
+    jval <<<"${allRules}" --input=read -- "${filterArgs[@]}"
 )" \
 || exit "$?"
 

--- a/bin/delete-subnets
+++ b/bin/delete-subnets
@@ -101,7 +101,7 @@ selectedSubnets="$(
 || exit "$?"
 
 subnetIds=($(
-    jval <<<"${selectedSubnets}" --output=words --slurp-stdin \
+    jval <<<"${selectedSubnets}" --output=words --input=slurp \
         'map(.SubnetId) | sort | .[]'
 )) \
 || exit "$?"

--- a/bin/delete-subnets
+++ b/bin/delete-subnets
@@ -101,7 +101,8 @@ selectedSubnets="$(
 || exit "$?"
 
 subnetIds=($(
-    jval <<<"${selectedSubnets}" --words --slurp-stdin 'map(.SubnetId) | sort | .[]'
+    jval <<<"${selectedSubnets}" --output=words --slurp-stdin \
+        'map(.SubnetId) | sort | .[]'
 )) \
 || exit "$?"
 

--- a/bin/delete-subnets
+++ b/bin/delete-subnets
@@ -116,5 +116,5 @@ for id in "${subnetIds[@]}"; do
 done
 
 if (( !quiet )); then
-    jarray --strings "${subnetIds[@]}"
+    jarray --input=strings "${subnetIds[@]}"
 fi

--- a/bin/delete-subnets
+++ b/bin/delete-subnets
@@ -96,7 +96,7 @@ allSubnets="$(ec2-json describe-subnets \
 || exit "$?"
 
 selectedSubnets="$(
-    jval <<<"${allSubnets}" --read-stdin -- "${filterArgs[@]}"
+    jval <<<"${allSubnets}" --input=read -- "${filterArgs[@]}"
 )" \
 || exit "$?"
 

--- a/bin/find-security-group
+++ b/bin/find-security-group
@@ -98,12 +98,12 @@ if (( count == 0 )); then
     exit 1
 elif (( count != 1 )); then
     echo 1>&2 'Ambiguous name or ID matches all of:'
-    jget --raw 1>&2 "${result}" '.all[] | "  " + .'
+    jget 1>&2 --output=raw "${result}" '.all[] | "  " + .'
     exit 1
 fi
 
 if [[ ${outputStyle} == 'print-all' ]]; then
     jget "${result}" '.group'
 else
-    jget --raw "${result}" '.group.GroupId'
+    jget --output=raw "${result}" '.group.GroupId'
 fi

--- a/bin/find-vpc
+++ b/bin/find-vpc
@@ -85,7 +85,7 @@ function do-find {
     )"
 
     local vpcId
-    vpcId="$(jget --raw \
+    vpcId="$(jget --output=raw \
         "${idResult}" \
         '
         if length == 0 then "none"
@@ -97,7 +97,7 @@ function do-find {
     case "${vpcId}" in
         ambiguous)
             echo 1>&2 'Ambiguous name or ID matches all of:'
-            jget 1>&2 --raw "${idResult}" '.[] | "  " + .'
+            jget 1>&2 --output=raw "${idResult}" '.[] | "  " + .'
             return 1
             ;;
         none)

--- a/bin/find-vpc-subnet
+++ b/bin/find-vpc-subnet
@@ -68,7 +68,7 @@ result="$(ec2-json describe-subnets \
 )" \
 || exit "$?"
 
-subnetId="$(jget --raw "${result}" '
+subnetId="$(jget --output=raw "${result}" '
     if length == 0 then "none"
     elif length == 1 then .[0]
     else "ambiguous"
@@ -78,7 +78,7 @@ subnetId="$(jget --raw "${result}" '
 case "${subnetId}" in
     ambiguous)
         echo 1>&2 'Ambiguous specification matches all of:'
-        jget 1>&2 --raw "${result}" '.[] | "  " + .'
+        jget 1>&2 --output=raw "${result}" '.[] | "  " + .'
         exit 1
         ;;
     none)

--- a/bin/lib/arg-processor
+++ b/bin/lib/arg-processor
@@ -143,6 +143,55 @@ function opt-choice {
     fi
 }
 
+# Declares an enumerated-value option, which requires a value when passed on a
+# commandline to be one of a specific listed set. No `<abbrev>` or `<value>` is
+# allowed in the argument spec. If left unspecified, the default variable value
+# for an enumerated-value option is `''` (the empty string). This definer also
+# accepts the `--required` option, but notably _not_ `--filter` (which is
+# effectively used "under the covers" to implement the value validity check).
+function opt-enum {
+    local optCall=''
+    local optDefault=''
+    local optRequired=0
+    local optVar=''
+    local args=("$@")
+    _argproc_janky-args --multi-spec call default required var \
+    || return 1
+
+    if (( ${#args[@]} < 2 )); then
+        echo 1>&2 'Missing enumerated values.'
+        return 1
+    fi
+
+    local specName=''
+    _argproc_parse-spec "${args[0]}" \
+    || return 1
+    unset args[0]
+
+    local filterExpr=''
+    local value
+    for value in "${args[@]}"; do
+        if ! [[ ${value} =~ ^[-_a-zA-Z0-9]*$ ]]; then
+            echo 1>&2 "Invalid enumerated value: ${value}"
+            return 1
+        fi
+        filterExpr+="|${value}"
+    done
+    filterExpr="/^(${filterExpr:1})$/" # ':1` to drop the extra `|`.
+
+    if [[ ${optVar} != '' ]]; then
+        # Set up the default initializer.
+        _argproc_initStatements+=("${optVar}=$(_argproc_quote "${optDefault}")")
+    fi
+
+    _argproc_define-value-required-arg --option \
+        "${specName}" "${optCall}" "${optVar}" "${filterExpr}"
+
+    if (( optRequired )); then
+        _argproc_add-required-arg-postcheck "${specName}"
+    fi
+}
+
 # Declares a "toggle" option, which does not accept a value on the commandline.
 # No `<value>` is allowed in the argument spec. The toggle state of off or on is
 # always indicated by a value of `0` or `1` (respectively). In addition to the

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -189,7 +189,7 @@ fi
 
 jsonArg='{}'
 if (( ${#argConstructor[@]} > 0 )); then
-    jsonArg="$(jval --compact -- "${argConstructor[@]}")" \
+    jsonArg="$(jval --output=compact -- "${argConstructor[@]}")" \
     || {
         echo 1>&2 'Trouble parsing argument constructor.'
         exit 1
@@ -210,7 +210,7 @@ if [[ -x ${specialCaseHandler} ]]; then
     dashArgsLength="$(jget "${commandParts}" '.dashArgs | length')"
     dashArgs=()
     for (( i = 0; i < dashArgsLength; i++ )); do
-        dashArgs+=("$(jval --raw p:json="${commandParts}" i:json="${i}" '$p.dashArgs[$i]')")
+        dashArgs+=("$(jval --output=raw p:json="${commandParts}" i:json="${i}" '$p.dashArgs[$i]')")
     done
 fi
 

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -203,9 +203,9 @@ if [[ -x ${specialCaseHandler} ]]; then
     commandParts="$("${specialCaseHandler}" "$(make-command-parts-json)")" \
     || exit 1
 
-    command="$(jget --raw "${commandParts}" '.command')"
-    subcommand="$(jget --raw "${commandParts}" '.subcommand')"
-    jsonArg="$(jget --compact "${commandParts}" '.jsonArg')"
+    command="$(jget --output=raw "${commandParts}" '.command')"
+    subcommand="$(jget --output=raw "${commandParts}" '.subcommand')"
+    jsonArg="$(jget --output=compact "${commandParts}" '.jsonArg')"
 
     dashArgsLength="$(jget "${commandParts}" '.dashArgs | length')"
     dashArgs=()
@@ -276,10 +276,10 @@ if [[ ${outputStyle} != 'none' ]]; then
     jgetOpts=()
     case "${outputStyle}" in
         compact)
-            jgetOpts+=('--compact')
+            jgetOpts+=('--output=compact')
             ;;
         raw)
-            jgetOpts+=('--raw')
+            jgetOpts+=('--output=raw')
             ;;
     esac
 

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -159,7 +159,7 @@ process-args "$@" || usage "$?"
 # Constructs a JSON value to represent all the pieces of a command, based on the
 # globals set up by the main script.
 function make-command-parts-json {
-    local dashArgsJson="$(jarray --strings -- "${dashArgs[@]}")"
+    local dashArgsJson="$(jarray --input=strings -- "${dashArgs[@]}")"
 
     jval \
         command="${command}" \
@@ -243,7 +243,7 @@ if [[ ${printCommandTo} != '' ]]; then
     # much every bit someone might care about.
     jval >"${printCommandTo}" \
         parts:json="$(make-command-parts-json)" \
-        full:json="$(jarray --strings "${fullCommand[@]}")" \
+        full:json="$(jarray --input=strings "${fullCommand[@]}")" \
         '
         def quoteMaybe:
             if test("^[-_/=a-zA-Z0-9]+$")

--- a/bin/lib/cidr-calc
+++ b/bin/lib/cidr-calc
@@ -217,7 +217,7 @@ function cidr-address-words-v6 {
 function cidr-from-json {
     local cidr="$1"
 
-    local type="$(jget --raw "${cidr}" '.type')"
+    local type="$(jget --output=raw "${cidr}" '.type')"
     local netmaskBits="$(jget "${cidr}" '.netmaskBits')"
     local address
 
@@ -242,7 +242,7 @@ function cidr-v4-address {
     local cidr="$1"
     local netmaskBits="$2"
 
-    local address="$(jget --raw "${cidr}" '
+    local address="$(jget --output=raw "${cidr}" '
         [
             ((.address[0] / 256) | floor | tostring),
             ((.address[0] % 256) | tostring),
@@ -260,7 +260,7 @@ function cidr-v6-address {
     local cidr="$1"
 
     local address="$(
-        jget --raw "${cidr}" '.address | map(tostring) | join(" ")'
+        jget --output=raw "${cidr}" '.address | map(tostring) | join(" ")'
     )"
 
     # Go from space-separated string to array of elements.
@@ -580,7 +580,7 @@ function command_address-words {
     cidr="$(json-from-any "${cidr}")" \
     || return "$?"
 
-    jget --raw "${cidr}" '.address | map(tostring) | join(" ")'
+    jget --output=raw "${cidr}" '.address | map(tostring) | join(" ")'
 }
 
 # Command: Print a list of subnets.
@@ -771,7 +771,7 @@ if [[ ${resultType} != 'text' ]]; then
             else
                 # It's an array. Compactly print each element on a line by
                 # itself, then split by lines to convert each object.
-                jget --compact "${result}" '.[]' \
+                jget --output=compact "${result}" '.[]' \
                 | while read -r line; do
                     cidr-from-json "${line}"
                 done

--- a/bin/lib/filter-spec
+++ b/bin/lib/filter-spec
@@ -79,8 +79,8 @@ process-args "$@" || usage "$?"
 #
 
 jval --"${outputStyle}" \
-    names:json="$(jarray --strings "${filterNames[@]}")" \
-    values:json="$(jarray --strings "${filterValues[@]}")" \
+    names:json="$(jarray --input=strings "${filterNames[@]}")" \
+    values:json="$(jarray --input=strings "${filterValues[@]}")" \
 '
     [$names, $values]
     |

--- a/bin/lib/filter-spec
+++ b/bin/lib/filter-spec
@@ -78,7 +78,7 @@ process-args "$@" || usage "$?"
 # Main script
 #
 
-jval --"${outputStyle}" \
+jval --output="${outputStyle}" \
     names:json="$(jarray --input=strings "${filterNames[@]}")" \
     values:json="$(jarray --input=strings "${filterValues[@]}")" \
 '

--- a/bin/lib/ip-permission-spec
+++ b/bin/lib/ip-permission-spec
@@ -69,7 +69,7 @@ if [[ ${protocol} == 'all' ]]; then
     protocol='-1'
 fi
 
-jval --"${outputStyle}" \
+jval --output="${outputStyle}" \
     port:json="${port}" \
     protocol="${protocol}" \
 '{

--- a/bin/lib/json-array
+++ b/bin/lib/json-array
@@ -22,15 +22,15 @@ function usage {
 
     ${name} [<opt> ...] [--] [<value> ...]
       Constructs and prints a JSON array of values, of all of the value
-      arguments passed to this script, each of which is interpreted as a
-      JSON value (default) or a string (with the appropriate option).
+      arguments passed to this command.
 
       --compact
         Output in compact (not multiline) JSON form.
       --json
         Output in JSON form. This is the default.
-      --strings (--no-strings to disable)
-        Treat arguments as literal strings instead of JSON values.
+      --input=<type>
+        `json` -- Treat arguments as JSON values. This is the default.
+        `strings` -- Treat arguments as literal strings.
 
     ${name} [--help | -h]
       Displays this message.
@@ -45,8 +45,8 @@ opt-action --call=usage help/h=0
 # Output style.
 opt-choice --var=outputStyle --default=json compact json
 
-# String arguments?
-opt-toggle --var=strings strings
+# Input style.
+opt-enum --var=inputStyle --default=json input json strings
 
 # The array elements.
 rest-arg --var=args
@@ -73,7 +73,7 @@ if [[ ${outputStyle} == 'compact' ]]; then
     jqArgs+=('--compact-output')
 fi
 
-if (( strings )); then
+if [[ ${inputStyle} == 'strings' ]]; then
     argOpt='--arg'
 else
     argOpt='--argjson'
@@ -88,4 +88,5 @@ for (( n = 0; n < ${#args[@]}; n++ )); do
     expr+='$a'"${n}"
 done
 
+echo 1>&2 '#######' "${inputStyle}"
 exec jq "${jqArgs[@]}" "[${expr}]"

--- a/bin/lib/json-array
+++ b/bin/lib/json-array
@@ -24,13 +24,12 @@ function usage {
       Constructs and prints a JSON array of values, of all of the value
       arguments passed to this command.
 
-      --compact
-        Output in compact (not multiline) JSON form.
-      --json
-        Output in JSON form. This is the default.
-      --input=<type>
+      --input=<style>
         `json` -- Treat arguments as JSON values. This is the default.
         `strings` -- Treat arguments as literal strings.
+      --output=<style>
+        `compact` -- Output in compact (single line) JSON form.
+        `json` -- Output in multiline JSON form. This is the default.
 
     ${name} [--help | -h]
       Displays this message.
@@ -43,7 +42,7 @@ function usage {
 opt-action --call=usage help/h=0
 
 # Output style.
-opt-choice --var=outputStyle --default=json compact json
+opt-enum --var=outputStyle --default=json output compact json
 
 # Input style.
 opt-enum --var=inputStyle --default=json input json strings
@@ -88,5 +87,4 @@ for (( n = 0; n < ${#args[@]}; n++ )); do
     expr+='$a'"${n}"
 done
 
-echo 1>&2 '#######' "${inputStyle}"
 exec jq "${jqArgs[@]}" "[${expr}]"

--- a/bin/lib/json-array
+++ b/bin/lib/json-array
@@ -63,7 +63,7 @@ process-args "$@" || usage "$?"
 # much simpler. Unfortunately, because `jq` doesn't actually do the usual shell
 # command behavior of not attempting to interpret things that look like options
 # but are positioned after non-option arguments, it's not actually possible to
-# use `--args` or `--json-args`, especially if we want to be resilient to errant
+# use `--args` or `--jsonargs`, especially if we want to be resilient to errant
 # input to this script (and not blithely pass it into a `jq` which will do
 # who-knows-what with it).
 

--- a/bin/lib/json-get
+++ b/bin/lib/json-get
@@ -28,19 +28,15 @@ function usage {
       no expression is given, it is taken to be `.`, which will end up just
       formatting the input value as implied/specified by the output options.
 
-      --compact
-        Output in compact (not multiline) JSON form.
-      --json
-        Output in JSON form. This is the default.
-      --lines
-        Output each item as a single line. Similar to `--raw`, except that
-        a strings with newlines or CRs in them get treated as non-raw so as
-        to maintain the guarantee of item-per-line.
-      --raw
-        Output raw strings (and other values compactly).
-      --words
-        Like `--lines`, except that the guarantee is a word per line. As such,
-        strings with any whitespace get treated as non-raw.
+      --output=<style>
+        `compact` -- Output in compact (single line) JSON form.
+        `json` -- Output in multiline JSON form. This is the default.
+        `lines` -- Output each item as a single line. Similar to `--raw`, except
+          that strings with newlines or CRs in them get treated as non-raw so as
+          to maintain the guarantee of item-per-line.
+        `raw` -- Output strings as raw text (and other values as `compact`).
+        `words` -- Like `--lines`, except that the guarantee is a word per line.
+          As such, strings containing whitespace get treated as non-raw.
 
     ${name} [--help | -h]
       Displays this message.
@@ -53,7 +49,7 @@ function usage {
 opt-action --call=usage help/h=0
 
 # Output style.
-opt-choice --var=outputStyle --default=json compact json lines raw words
+opt-enum --var=outputStyle --default=json output compact json lines raw words
 
 # Value to operate on.
 positional-arg --required --var=value value
@@ -72,4 +68,5 @@ if (( ${#exprArgs[@]} == 0 )); then
     exprArgs=('.')
 fi
 
-lib json-val <<< "${value}" --output="${outputStyle}" --input=read -- "${exprArgs[@]}"
+lib json-val <<< "${value}" --output="${outputStyle}" --input=read -- \
+    "${exprArgs[@]}"

--- a/bin/lib/json-get
+++ b/bin/lib/json-get
@@ -72,4 +72,4 @@ if (( ${#exprArgs[@]} == 0 )); then
     exprArgs=('.')
 fi
 
-lib json-val <<< "${value}" --"${outputStyle}" --input=read -- "${exprArgs[@]}"
+lib json-val <<< "${value}" --output="${outputStyle}" --input=read -- "${exprArgs[@]}"

--- a/bin/lib/json-get
+++ b/bin/lib/json-get
@@ -72,4 +72,4 @@ if (( ${#exprArgs[@]} == 0 )); then
     exprArgs=('.')
 fi
 
-lib json-val <<< "${value}" --"${outputStyle}" --read-stdin -- "${exprArgs[@]}"
+lib json-val <<< "${value}" --"${outputStyle}" --input=read -- "${exprArgs[@]}"

--- a/bin/lib/json-val
+++ b/bin/lib/json-val
@@ -34,24 +34,20 @@ function usage {
         <name>=<value> Assign `$name` to be the indicated string value.
         <name>:json=<value> Assign `$name` to be the indicated parsed JSON value.
 
-      --compact
-        Output in compact (not multiline) JSON form.
       --input=<style>
         `null` -- Do not read from stdin. This is the default.
         `read` -- Read values from stdin individually to form pipeline input.
         `slurp` -- Read all values from stdin into a single array, producing a
           single-value pipeline input.
-      --json
-        Output in JSON form. This is the default.
-      --lines
-        Output each item as a single line. Similar to `--raw`, except that
-        a strings with newlines or CRs in them get treated as non-raw so as
-        to maintain the guarantee of item-per-line.
-      --raw
-        Output raw strings (and other values compactly).
-      --words
-        Like `--lines`, except that the guarantee is a word per line. As such,
-        strings with any whitespace get treated as non-raw.
+      --output=<style>
+        `compact` -- Output in compact (single line) JSON form.
+        `json` -- Output in multiline JSON form. This is the default.
+        `lines` -- Output each item as a single line. Similar to `--raw`, except
+          that strings with newlines or CRs in them get treated as non-raw so as
+          to maintain the guarantee of item-per-line.
+        `raw` -- Output strings as raw text (and other values as `compact`).
+        `words` -- Like `--lines`, except that the guarantee is a word per line.
+          As such, strings containing whitespace get treated as non-raw.
 
     ${name} [--help | -h]
       Displays this message.
@@ -67,7 +63,7 @@ opt-action --call=usage help/h=0
 opt-enum --var=inputStyle --default=null input null read slurp
 
 # Output style.
-opt-choice --var=outputStyle --default=json compact json lines raw words
+opt-enum --var=outputStyle --default=json output compact json lines raw words
 
 # List of variable assignments, as parallel arrays of type, name, and value.
 varTypes=()

--- a/bin/lib/json-val
+++ b/bin/lib/json-val
@@ -36,20 +36,19 @@ function usage {
 
       --compact
         Output in compact (not multiline) JSON form.
+      --input=<style>
+        `null` -- Do not read from stdin. This is the default.
+        `read` -- Read values from stdin individually to form pipeline input.
+        `slurp` -- Read all values from stdin into a single array, producing a
+          single-value pipeline input.
       --json
         Output in JSON form. This is the default.
       --lines
         Output each item as a single line. Similar to `--raw`, except that
         a strings with newlines or CRs in them get treated as non-raw so as
         to maintain the guarantee of item-per-line.
-      --null-stdin
-        Do not read from stdin. This is the default.
       --raw
         Output raw strings (and other values compactly).
-      --read-stdin
-        Read value(s) from stdin to form pipeline input.
-      --slurp-stdin
-        Read all values from stdin into a single array pipeline input.
       --words
         Like `--lines`, except that the guarantee is a word per line. As such,
         strings with any whitespace get treated as non-raw.
@@ -65,7 +64,7 @@ function usage {
 opt-action --call=usage help/h=0
 
 # Input style.
-opt-choice --var=inputStyle --default=null-stdin null-stdin read-stdin slurp-stdin
+opt-enum --var=inputStyle --default=null input null read slurp
 
 # Output style.
 opt-choice --var=outputStyle --default=json compact json lines raw words
@@ -126,13 +125,13 @@ process-args "$@" || usage "$?"
 jqArgs=()
 
 case "${inputStyle}" in
-    null-stdin)
+    null)
         jqArgs+=('--null-input')
         ;;
-    read-stdin)
+    read)
         : # No additional arguments needed.
         ;;
-    slurp-stdin)
+    slurp)
         jqArgs+=('--slurp')
         ;;
 esac

--- a/bin/lib/name-tag-spec
+++ b/bin/lib/name-tag-spec
@@ -59,7 +59,7 @@ process-args "$@" || usage "$?"
 # Main script
 #
 
-jval --"${outputStyle}" \
+jval --output="${outputStyle}" \
     name="${name}" \
     resourceType="${resourceType}" \
     '{

--- a/bin/make-instance
+++ b/bin/make-instance
@@ -121,7 +121,7 @@ amiInfo="$(
     ${progDir}/find-ami --loc="${zone}" --instance-type="${instanceType}")" \
 || exit "$?"
 
-jget 1>&2 --raw "${amiInfo}" '
+jget 1>&2 --output=raw "${amiInfo}" '
     "Using AMI:",
     "  desc: " + .Description,
     "  name: " + .Name,

--- a/bin/make-vpc
+++ b/bin/make-vpc
@@ -81,7 +81,7 @@ function make-vpc-per-se {
             )" \
             || return "$?"
 
-            vpcId="$(jget --raw "${vpcInfo}" '.VpcId')"
+            vpcId="$(jget --output=raw "${vpcInfo}" '.VpcId')"
             echo 1>&2 "Made VPC: ${vpcId}"
         else
             # Re-fetch the VPC info.
@@ -102,7 +102,7 @@ function make-vpc-per-se {
         # then it's safe to assume that all network addresses are `associated`.
         # However, that doesn't seem to be explicitly stated in the AWS docs, so
         # we test explicitly for the network associations.
-        local ready="$(jget --raw "${vpcInfo}" '
+        local ready="$(jget --output=raw "${vpcInfo}" '
               .CidrBlockAssociationSet[0].CidrBlockState as $cidr4
             | .Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlockState as $cidr6
             |
@@ -157,9 +157,9 @@ resourceName="standard-for-${name}"
 vpcInfo="$(make-vpc-per-se)" \
 || exit "$?"
 
-vpcId="$(jget --raw "${vpcInfo}" '.VpcId')"
-cidr4="$(jget --raw "${vpcInfo}" '.CidrBlockAssociationSet[0].CidrBlock')"
-cidr6="$(jget --raw "${vpcInfo}" '.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock')"
+vpcId="$(jget --output=raw "${vpcInfo}" '.VpcId')"
+cidr4="$(jget --output=raw "${vpcInfo}" '.CidrBlockAssociationSet[0].CidrBlock')"
+cidr6="$(jget --output=raw "${vpcInfo}" '.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock')"
 
 echo 1>&2 'Networks:'
 echo 1>&2 "  IPv4: ${cidr4}"

--- a/bin/set-attributes
+++ b/bin/set-attributes
@@ -136,7 +136,7 @@ error=0
 for (( n = 0; n < ${#assignNames[@]}; n++ )); do
     name="${assignNames[${n}]}"
     value="${assignValues[${n}]}"
-    valueType="$(jget --raw "${skeleton}" \
+    valueType="$(jget --output=raw "${skeleton}" \
         name="${name}" '
         if (has($name) | not)
         then
@@ -158,7 +158,7 @@ for (( n = 0; n < ${#assignNames[@]}; n++ )); do
         boolean|null|number)
             # These are okay without alteration, just need to validate JSON
             # form.
-            value="$(jget 2>/dev/null --compact "${value}" '.')" \
+            value="$(jget 2>/dev/null --output=compact "${value}" '.')" \
             || jsonError=1
             ;;
         string)
@@ -169,7 +169,7 @@ for (( n = 0; n < ${#assignNames[@]}; n++ )); do
         value-boolean)
             # Wrap the value.
             value="$(
-                jget 2>/dev/null --compact "${value}" '{ Value: . }'
+                jget 2>/dev/null --output=compact "${value}" '{ Value: . }'
             )" \
             || jsonError=1
             ;;


### PR DESCRIPTION
This adds `opt-enum`, as a reasonably better alternative to `opt-choice` in many cases. This also converts all the JSON-value commands' input and output options to instead be `--input` and `--output` enums.