### PR TITLE
`aws-json` output options.

### DIFF
--- a/bin/add-internet-gateway
+++ b/bin/add-internet-gateway
@@ -73,7 +73,7 @@ function figure-out-name {
     name=$(ec2-json describe-vpcs \
         --loc="${region}" \
         "$(lib filter-spec vpc-id="${vpcId}")" \
-        :: --raw \
+        :: --output=raw \
         '.Vpcs[0].Tags[] | select(.Key == "Name") | .Value'
     ) \
     || return "$?"
@@ -110,7 +110,7 @@ fi
 gatewayId="$(ec2-json create-internet-gateway \
     --loc="${region}" \
     "$(lib name-tag-spec internet-gateway "${name}")" \
-    :: --raw '.InternetGateway.InternetGatewayId'
+    :: --output=raw '.InternetGateway.InternetGatewayId'
 )" \
 || exit "$?"
 
@@ -126,7 +126,7 @@ rtId="$(ec2-json describe-route-tables \
     --loc="${region}" \
     filters:json="$(lib filter-spec vpc-id="${vpcId}" association.main=true)" \
     '$filters' \
-    :: --raw '.RouteTables[0].RouteTableId'
+    :: --output=raw '.RouteTables[0].RouteTableId'
 )" \
 && progress-msg "Default VPC route table: ${rtId}" \
 || error=1

--- a/bin/add-internet-gateway
+++ b/bin/add-internet-gateway
@@ -159,7 +159,7 @@ if (( !error && usesIpv4 )); then
             DestinationCidrBlock: "0.0.0.0/0",
             GatewayId: $gatewayId
         }' \
-        :: --none \
+        :: --output=none \
     && v4RouteAdded=1 \
     && progress-msg 'Added IPv4 route.' \
     || error=1
@@ -177,7 +177,7 @@ if (( !error && usesIpv6 )); then
             DestinationIpv6CidrBlock: "::/0",
             GatewayId: $gatewayId
         }' \
-        :: --none \
+        :: --output=none \
     && v6RouteAdded=1 \
     && progress-msg 'Added IPv6 route.' \
     || error=1

--- a/bin/add-ip-security-group-rules
+++ b/bin/add-ip-security-group-rules
@@ -105,7 +105,7 @@ ipSpec="$(lib ip-permission-spec "${protocol}" "${port}")" \
 
 filterArg='.SecurityGroupRules | map(.SecurityGroupRuleId)'
 if (( quiet )); then
-    filterArg='--none'
+    filterArg='--output=none'
 fi
 
 ec2-json "${command}" \

--- a/bin/add-subnets
+++ b/bin/add-subnets
@@ -161,7 +161,7 @@ for (( n = 0; n < azCount && !error; n++ )); do
             else { Ipv6CidrBlock: $v6Subnet }
         end
         ' \
-        :: --raw '.Subnet.SubnetId' \
+        :: --output=raw '.Subnet.SubnetId' \
     )" \
     || error=1
 

--- a/bin/configure-security-group
+++ b/bin/configure-security-group
@@ -143,7 +143,7 @@ if (( !error )); then
                 }]
             }]
         }' \
-        :: --none \
+        :: --output=none \
     && progress-msg "Added within-group rule." \
     || error="$?"
 fi

--- a/bin/delete-internet-gateway
+++ b/bin/delete-internet-gateway
@@ -85,7 +85,7 @@ if [[ ${vpcId} != 'null' ]]; then
         --loc="${region}" \
         filters:json="$(lib filter-spec vpc-id="${vpcId}" association.main=true)" \
         '$filters' \
-        :: --raw '.RouteTables[0]'
+        :: --output=raw '.RouteTables[0]'
     )" \
     || exit "$?"
 

--- a/bin/delete-security-group-rules
+++ b/bin/delete-security-group-rules
@@ -130,7 +130,7 @@ if [[ ${egressRuleIds} != '[]' ]]; then
             GroupId: $groupId,
             SecurityGroupRuleIds: $ruleIds
         }' \
-        :: --none \
+        :: --output=none \
     || exit "$?"
 fi
 
@@ -144,7 +144,7 @@ if [[ ${ingressRuleIds} != '[]' ]]; then
             GroupId: $groupId,
             SecurityGroupRuleIds: $ruleIds
         }' \
-        :: --none \
+        :: --output=none \
     || exit "$?"
 fi
 

--- a/bin/find-ami
+++ b/bin/find-ami
@@ -93,7 +93,7 @@ ec2-json describe-instance-types \
     --loc="${zone}" \
     instanceType="${instanceType}" \
     '{ InstanceTypes: [$instanceType] }' \
-    :: --raw '
+    :: --output=raw '
         .InstanceTypes[0].ProcessorInfo.SupportedArchitectures
         | map(select(. != "i386"))
         | .[0] // "error"

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -47,12 +47,10 @@ function usage {
 
     Output options:
 
-    --compact
-      Output in compact form (not multiline JSON).
-    --none
-      Do not produce (non-error) output.
-    --raw
-      Output raw strings (and other values compactly).
+    --output=<style> :: `compact` `json` `none` `raw`
+      How to process the final output. All options are as with `json-val`, with
+      the addition of `none` which means that nothing should be output. The
+      default is `json`.
 
     ${name} [--help | -h]
       Displays this message.
@@ -89,7 +87,7 @@ opt-action --var=skeleton skeleton
 require-exactly-one-arg-of loc skeleton
 
 # Output style (result post-processor option).
-outputStyle=normal
+outputStyle=json
 
 # Assignments and expression arguments to use to construct the value to pass to
 # the AWS command.
@@ -119,6 +117,13 @@ function parse-rest {
     # Process result post-processor arguments.
     while (( $# > 0 )); do
         case "$1" in
+            --output=*)
+                outputStyle="${1#*=}"
+                if ! [[ "${outputStyle}" =~ ^(compact|json|none|raw)$ ]]; then
+                    echo 1>&2 "Invalid result output style: ${outputStyle}"
+                    return 1
+                fi
+                ;;
             --compact)
                 outputStyle=compact
                 ;;
@@ -275,11 +280,8 @@ fi
 if [[ ${outputStyle} != 'none' ]]; then
     jgetOpts=()
     case "${outputStyle}" in
-        compact)
-            jgetOpts+=('--output=compact')
-            ;;
-        raw)
-            jgetOpts+=('--output=raw')
+        compact|json|raw)
+            jgetOpts+=(--output="${outputStyle}")
             ;;
     esac
 

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -124,15 +124,6 @@ function parse-rest {
                     return 1
                 fi
                 ;;
-            --compact)
-                outputStyle=compact
-                ;;
-            --none)
-                outputStyle=none
-                ;;
-            --raw)
-                outputStyle=raw
-                ;;
             --)
                 # Explicit end of options.
                 shift

--- a/bin/lib/aws-json
+++ b/bin/lib/aws-json
@@ -47,7 +47,7 @@ function usage {
 
     Output options:
 
-    --output=<style> :: `compact` `json` `none` `raw`
+    --output=<style> :: `compact` `json` `lines` `none` `raw` `words`
       How to process the final output. All options are as with `json-val`, with
       the addition of `none` which means that nothing should be output. The
       default is `json`.
@@ -119,7 +119,7 @@ function parse-rest {
         case "$1" in
             --output=*)
                 outputStyle="${1#*=}"
-                if ! [[ "${outputStyle}" =~ ^(compact|json|none|raw)$ ]]; then
+                if ! [[ "${outputStyle}" =~ ^(compact|json|lines|none|raw|words)$ ]]; then
                     echo 1>&2 "Invalid result output style: ${outputStyle}"
                     return 1
                 fi

--- a/bin/list-availability-zones
+++ b/bin/list-availability-zones
@@ -53,17 +53,12 @@ process-args "$@" || usage "$?"
 # Main script
 #
 
-cmd=(ec2-json describe-availability-zones --loc="${region}" ::)
-suffix=()
+cmd=(ec2-json describe-availability-zones
+    --loc="${region}"
+    :: --output="${outputStyle}" '.AvailabilityZones | map(.ZoneName) | sort')
 
-case "${outputStyle}" in
-    compact)
-        cmd+=(--output=compact)
-        ;;
-    lines)
-        cmd+=(--output=raw)
-        suffix=('| .[]')
-        ;;
-esac
+if [[ "${outputStyle}" == 'lines' ]]; then
+    cmd+=('| .[]')
+fi
 
-"${cmd[@]}" '.AvailabilityZones | map(.ZoneName) | sort' "${suffix[@]}"
+"${cmd[@]}"

--- a/bin/list-availability-zones
+++ b/bin/list-availability-zones
@@ -58,7 +58,7 @@ suffix=()
 
 case "${outputStyle}" in
     compact)
-        cmd+=(--compact)
+        cmd+=(--output=compact)
         ;;
     lines)
         cmd+=(--output=raw)

--- a/bin/list-availability-zones
+++ b/bin/list-availability-zones
@@ -61,7 +61,7 @@ case "${outputStyle}" in
         cmd+=(--compact)
         ;;
     lines)
-        cmd+=(--raw)
+        cmd+=(--output=raw)
         suffix=('| .[]')
         ;;
 esac

--- a/bin/make-security-group
+++ b/bin/make-security-group
@@ -83,7 +83,7 @@ function figure-out-name {
     name=$(ec2-json describe-vpcs \
         --loc="${region}" \
         "$(lib filter-spec vpc-id="${vpcId}")" \
-        :: --raw \
+        :: --output=raw \
         '.Vpcs[0].Tags[] | select(.Key == "Name") | .Value'
     ) \
     || return "$?"
@@ -129,7 +129,7 @@ groupId="$(ec2-json create-security-group \
             VpcId: $vpcId
         }
     ' \
-    :: --raw '.GroupId'
+    :: --output=raw '.GroupId'
 )" \
 || exit "$?"
 


### PR DESCRIPTION
This reworks the output options from `aws-json` to be an enum `--output`, like `json-val` etc.