### PR TITLE
Switch to the new `--filter` implementation style

### DIFF
--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -30,10 +30,12 @@
 # Value-accepting argument definers allow these additional options to pre-filter
 # a value, before it gets set or passed to a `--call`:
 # * `--filter=<name>` or `filter={code}` -- Calls the named function passing it
-#   a single argument value, or runs the indicated code snippet. The function
-#   or snippet must output a replacement value. If the call fails, the argument
-#   is rejected. Note: The filter runs in a subshell, and as such it cannot be
-#   used to affect the global environment of the main script.
+#   a single argument value, or runs the indicated code snippet. The function or
+#   code can do one of the following:
+#   * Return without error to accept the value as-is.
+#   * Return a non-zero code (and perhaps print an error message) to indicate an
+#     invalid value.
+#   * Call `replace-value <value>` to provide a replacement value.
 # * `--filter=/<regex>/` -- Matches each argument value against the regex. If
 #   the regex doesn't match, the argument is rejected. The regex must be
 #   non-empty.
@@ -333,6 +335,15 @@ function process-args {
         return "${_argproc_error}"
     fi
 }
+
+# Used during `--filter=` invocations as a callback from client code to indicate
+# that a value is to be replaced.
+function replace-value {
+    _argproc_filteredValues+=("$1")
+    _argproc_replaceCalled=1
+}
+_argproc_filteredValues=()
+_argproc_replaceCalled=0
 
 # Requires that exactly one of the indicated arguments / options is present.
 function require-exactly-one-arg-of {
@@ -663,44 +674,51 @@ function _argproc_error-coda {
 # Helper (called by code produced by `_argproc_handler-body`) which performs
 # a filter call. Upon success, prints all the filtered values.
 function _argproc_filter-call {
-    local desc="$1"
-    local filter="$2"
+    # Note: We use prefixed local variables to avoid a variable shadowing
+    # collision, because this function calls back to client code.
+    local _argproc_desc="$1"
+    local _argproc_filter="$2"
     shift 2
 
     # Kinda gross, but converting a non-call form to a function makes the
     # evaluation much more straightforward.
-    local definedFunc=1 filterCall='_argproc_filter-call:inner'
-    if [[ ${filter} =~ ^/(.*)/$ ]]; then
-        filter="$(vals -- "${BASH_REMATCH[1]}")"
-        eval "function ${filterCall} {
-            local _argproc_regex=${filter}
-            [[ \$1 =~ \${_argproc_regex} ]] && printf '%s\\n' \"\$1\"
+    local _argproc_definedFunc=1
+    local _argproc_filterCall='_argproc_filter-call:inner'
+    if [[ ${_argproc_filter} =~ ^/(.*)/$ ]]; then
+        _argproc_filter="$(vals -- "${BASH_REMATCH[1]}")"
+        eval "function ${_argproc_filterCall} {
+            local _argproc_regex=${_argproc_filter}
+            [[ \$1 =~ \${_argproc_regex} ]]
         }"
-    elif [[ ${filter} =~ ^\{(.*)\}$ ]]; then
-        filter="${BASH_REMATCH[1]}"
-        eval "function ${filterCall} {
-            ${filter}
+    elif [[ ${_argproc_filter} =~ ^\{(.*)\}$ ]]; then
+        _argproc_filter="${BASH_REMATCH[1]}"
+        eval "function ${_argproc_filterCall} {
+            ${_argproc_filter}
         }"
     else
-        definedFunc=0
-        filterCall="${filter}"
+        _argproc_definedFunc=0
+        _argproc_filterCall="${_argproc_filter}"
     fi
 
-    local arg result error=0
-    for arg in "$@"; do
-        if ! result=("$("${filterCall}" "${arg}")"); then
-            error-msg "Invalid value for ${desc}: ${arg}"
-            error=1
+    _argproc_filteredValues=()
+    local _argproc_arg _argproc_error=0
+    for _argproc_arg in "$@"; do
+        _argproc_replaceCalled=0
+        if ! "${_argproc_filterCall}" "${_argproc_arg}"; then
+            error-msg "Invalid value for ${_argproc_desc}: ${_argproc_arg}"
+            _argproc_error=1
             break
         fi
-        vals -- "${result}"
+        if (( !_argproc_replaceCalled )); then
+            replace-value "${_argproc_arg}"
+        fi
     done
 
-    if (( definedFunc )); then
-        unset -f "${filterCall}"
+    if (( _argproc_definedFunc )); then
+        unset -f "${_argproc_filterCall}"
     fi
 
-    return "${error}"
+    return "${_argproc_error}"
 }
 
 # Produces an argument handler body, from the given components.
@@ -715,15 +733,8 @@ function _argproc_handler-body {
         # Add a call to perform the filtering on all the arguments.
         local desc="$(_argproc_arg-description "${specName}")"
         result+=("$(printf '
-            local _argproc_args
-            _argproc_args="$(_argproc_filter-call %q %q "$@")" \
-            && set-array-from-vals _argproc_args "${_argproc_args}" \
-            || {
-                local error="$?"
-                error-msg --suppress-cmd
-                return "${error}"
-            }
-            set -- "${_argproc_args[@]}"' \
+            _argproc_filter-call %q %q "$@" || return "$?"
+            set -- "${_argproc_filteredValues[@]}"' \
             "${desc}" "${filter}"
         )")
     fi
@@ -909,7 +920,7 @@ function _argproc_parse-enum {
             printf '%s%s' "${or}" "$(vals --dollar -- "${value}")"
             or='|'
         done
-        printf $')$ ]] && printf \'%%s\' "$1" }'
+        printf $')$ ]] }'
     )"
 }
 

--- a/scripts/lib/milky-cloud/_setup.sh
+++ b/scripts/lib/milky-cloud/_setup.sh
@@ -34,3 +34,10 @@ function parse-zone {
 function region-from-location {
     lib parse-location --output=region "$@"
 }
+
+# Calls `region-from-location` (above) as an argument filter.
+function region-from-location-filter {
+    local region
+    region="$(lib parse-location --output=region "$@")" \
+    && replace-value "${region}"
+}

--- a/scripts/lib/milky-cloud/add-internet-gateway
+++ b/scripts/lib/milky-cloud/add-internet-gateway
@@ -33,7 +33,7 @@ define-usage --with-help $'
 usual-stderr-args
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name of the resulting gateway.
 opt-value --var=name --filter='/./' name

--- a/scripts/lib/milky-cloud/add-ip-security-group-rules
+++ b/scripts/lib/milky-cloud/add-ip-security-group-rules
@@ -59,7 +59,7 @@ opt-alias ingress --direction=ingress
 opt-value --required --var=groupNameOrId --filter='/./' security-group
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name of the rule.
 opt-value --var=name --filter='/./' name

--- a/scripts/lib/milky-cloud/add-subnets
+++ b/scripts/lib/milky-cloud/add-subnets
@@ -47,7 +47,7 @@ usual-json-output-args --no-rest
 opt-toggle --var=useIpv4 --default=1 ipv4
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name for the subnets.
 opt-value --var=name --filter='/./' name

--- a/scripts/lib/milky-cloud/aws-json
+++ b/scripts/lib/milky-cloud/aws-json
@@ -63,7 +63,7 @@ fi
 usual-json-output-args --no-output --no-rest
 
 # Region, passed as either region per se or availability zone.
-opt-value --var=region --filter=region-from-location loc
+opt-value --var=region --filter=region-from-location-filter loc
 
 # File to print the constructed command to.
 opt-value --filter='/./' --var=printCommandTo print-command-to

--- a/scripts/lib/milky-cloud/configure-security-group
+++ b/scripts/lib/milky-cloud/configure-security-group
@@ -40,7 +40,7 @@ define-usage --with-help $'
 usual-stderr-args
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name for the security group.
 opt-value --var=name --filter='/./' name

--- a/scripts/lib/milky-cloud/delete-internet-gateway
+++ b/scripts/lib/milky-cloud/delete-internet-gateway
@@ -29,7 +29,7 @@ define-usage --with-help $'
 usual-stderr-args
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # ID of the gateway.
 opt-value --required --var=gatewayId --filter='/./' gateway

--- a/scripts/lib/milky-cloud/delete-security-group-rules
+++ b/scripts/lib/milky-cloud/delete-security-group-rules
@@ -53,7 +53,7 @@ opt-alias all-egress  --filter='select(.IsEgress == true)'
 opt-alias all-ingress --filter='select(.IsEgress == false)'
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name or ID of the security group.
 opt-value --required --var=groupNameOrId --filter='/./' security-group

--- a/scripts/lib/milky-cloud/delete-subnets
+++ b/scripts/lib/milky-cloud/delete-subnets
@@ -48,7 +48,7 @@ opt-alias all --filter='.'
 opt-value --var=simpleFilter --filter='/./' filter
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name or ID of the VPC.
 opt-value --required --var=vpcNameOrId --filter='/./' vpc

--- a/scripts/lib/milky-cloud/find-security-group
+++ b/scripts/lib/milky-cloud/find-security-group
@@ -31,7 +31,7 @@ define-usage --with-help $'
 '
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Ok if no security group found?
 opt-toggle --var=notFoundOk not-found-ok

--- a/scripts/lib/milky-cloud/find-vpc
+++ b/scripts/lib/milky-cloud/find-vpc
@@ -28,7 +28,7 @@ define-usage --with-help $'
 '
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Ok if no VPC found?
 opt-toggle --var=notFoundOk not-found-ok

--- a/scripts/lib/milky-cloud/list-availability-zones
+++ b/scripts/lib/milky-cloud/list-availability-zones
@@ -24,7 +24,7 @@ define-usage --with-help $'
 '
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Output style.
 opt-value --var=outputStyle --default=lines --enum[]='compact json lines' output

--- a/scripts/lib/milky-cloud/make-security-group
+++ b/scripts/lib/milky-cloud/make-security-group
@@ -37,7 +37,7 @@ define-usage --with-help $'
 usual-stderr-args
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Description of the resulting security group.
 opt-value --var=description --filter='/./' description

--- a/scripts/lib/milky-cloud/make-vpc
+++ b/scripts/lib/milky-cloud/make-vpc
@@ -39,7 +39,7 @@ opt-toggle --var=useIpv4 --default=1 ipv4
 opt-toggle --var=useIpv6 --default=1 ipv6
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # Name for the resulting VPC.
 opt-value --required --var=name --filter='/^[-_a-zA-Z0-9]+$/' name

--- a/scripts/lib/milky-cloud/set-attributes
+++ b/scripts/lib/milky-cloud/set-attributes
@@ -32,7 +32,7 @@ define-usage --with-help $'
 usual-stderr-args
 
 # Region, passed as either region per se or availability zone.
-opt-value --required --var=region --filter=region-from-location loc
+opt-value --required --var=region --filter=region-from-location-filter loc
 
 # ID of the thing to operate on.
 opt-value --required --var=id --filter='/^[-a-z0-9]+$/' id


### PR DESCRIPTION
This PR updates Bashy-lib along with migrating use sites of `--filter` that thereby needed to be updated.